### PR TITLE
Implement method to get world coordinates in PickIntersection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,15 +57,15 @@ impl PickIntersection {
         }
     }
 
-    pub fn get_pick_world_pos(&self, projection_matrix: Mat4, view_matrix: Mat4) -> Vec3 {
+    pub fn get_pick_coord_ndc(&self) -> Vec3 {
+        self.pick_coord_ndc
+    }
+
+    pub fn get_pick_coord_world(&self, projection_matrix: Mat4, view_matrix: Mat4) -> Vec3 {
         let world_pos: Vec4 = (projection_matrix * view_matrix)
             .inverse()
             .mul_vec4(self.pick_coord_ndc.extend(1.0));
         (world_pos / world_pos.w()).truncate().into()
-    }
-
-    pub fn get_pick_coord_ndc(&self) -> Vec3 {
-        self.pick_coord_ndc
     }
 }
 


### PR DESCRIPTION
I started some work on #9. It's a simple function that transforms the ndc coordinate into world coordinate, and takes in a view and projection matrix. 

I'm not sure if this is the best way to implement it, I'm open to ideas. I just needed something to get going :P.

As a side note, here's what I'm using it for:

![bavy](https://user-images.githubusercontent.com/29580620/92305596-07e18680-ef89-11ea-8e2e-1ef75a6b5d66.gif)
