### PR TITLE
Fix for vertices flipping sign when behind camera

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,8 +367,8 @@ fn pick_mesh(
                             // by w perspective math for us, instead we have to do it manually.
                             // `glam` PR https://github.com/bitshifter/glam-rs/pull/75/files
                             let transformed = projection_matrix.mul_vec4(vertex_pos.extend(1.0));
-                            let w = transformed.w();
-                            triangle[i] = Vec3::from(transformed.truncate() / f32::abs(w));
+                            let w = transformed.w().abs();
+                            triangle[i] = Vec3::from(transformed.truncate() / w);
                         }
                         if point_in_tri(
                             &cursor_pos_ndc,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,8 +367,8 @@ fn pick_mesh(
                             // by w perspective math for us, instead we have to do it manually.
                             // `glam` PR https://github.com/bitshifter/glam-rs/pull/75/files
                             let transformed = projection_matrix.mul_vec4(vertex_pos.extend(1.0));
-                            let w = transformed.w().abs();
-                            triangle[i] = Vec3::from(transformed.truncate() / w);
+                            let w_recip = transformed.w().abs().recip();
+                            triangle[i] = Vec3::from(transformed.truncate() * w_recip);
                         }
                         if point_in_tri(
                             &cursor_pos_ndc,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,7 @@ fn pick_mesh(
                             // `glam` PR https://github.com/bitshifter/glam-rs/pull/75/files
                             let transformed = projection_matrix.mul_vec4(vertex_pos.extend(1.0));
                             let w = transformed.w();
-                            triangle[i] = Vec3::from(transformed.truncate() / w);
+                            triangle[i] = Vec3::from(transformed.truncate() / f32::abs(w));
                         }
                         if point_in_tri(
                             &cursor_pos_ndc,


### PR DESCRIPTION
Initial testing seems to show this resolves #15 . For perspective, `w` should always be positive, and only serves to scale verts to simulate perspective. When `w` became negative it would scale and invert vertices on their axes.