### PR TITLE
Add function to calculate hit_depth

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,8 +392,12 @@ fn pick_mesh(
                                 &Vec2::new(triangle[2].x(), triangle[2].y()),
                             ) {
                                 hit_found = true;
-                                if triangle[0].z() < hit_depth {
-                                    hit_depth = triangle[0].z();
+
+                                // Calculate the actual intersection depth
+                                let depth = triangle_depth(cursor_pos_ndc, triangle);
+                                // Keep the closest depth
+                                if depth < hit_depth {
+                                    hit_depth = depth;
                                 }
                             }
                         }
@@ -472,4 +476,17 @@ fn triangle_behind_cam(triangle: [Vec3; 3]) -> bool {
         .fold(-1.0, |max, x| if x.z() > max { x.z() } else { max });
     // If the maximum z value is less than zero, all vertices are behind the camera
     max_z < 0.0
+}
+
+/// Calculate the intersection depth in the triangle. Assumes that the cursor is inside the triangle
+fn triangle_depth(cursor_ndc: Vec2, triangle: [Vec3; 3]) -> f32 {
+    // From option 2 in https://stackoverflow.com/a/42752998
+
+    let a_to_b = triangle[1] - triangle[0];
+    let a_to_c = triangle[2] - triangle[0];
+    let normal = a_to_b.cross(a_to_c);
+
+    let direction = Vec3::new(0.0, 0.0, -1.0);
+
+    return -(triangle[0] - cursor_ndc.extend(0.0)).dot(normal) / direction.dot(normal);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,7 +394,7 @@ fn pick_mesh(
                                 hit_found = true;
 
                                 // Calculate the actual intersection depth
-                                let depth = triangle_depth(cursor_pos_ndc, triangle);
+                                let depth = triangle_depth_ndc(cursor_pos_ndc, triangle);
                                 // Keep the closest depth
                                 if depth < hit_depth {
                                     hit_depth = depth;
@@ -479,7 +479,7 @@ fn triangle_behind_cam(triangle: [Vec3; 3]) -> bool {
 }
 
 /// Calculate the intersection depth in the triangle. Assumes that the cursor is inside the triangle
-fn triangle_depth(cursor_ndc: Vec2, triangle: [Vec3; 3]) -> f32 {
+fn triangle_depth_ndc(cursor_ndc: Vec2, triangle: [Vec3; 3]) -> f32 {
     // From option 2 in https://stackoverflow.com/a/42752998
 
     let a_to_b = triangle[1] - triangle[0];


### PR DESCRIPTION
This PR fixes `hit_depth` calculation as mentioned in #5 , using a formula for intersection between triangle and line. 

I have tested it by creating a small 3d cursor that shows the hit position, and it works great. I haven't added the cursor in this PR, it's currently just a ball and a system in the 3d_scene example. I was thinking of moving it into `lib.rs` and opening a new PR. Thoughts?

Here's a little gif of world coordinates working correctly with the new `hit_depth`:

![bavy_pr](https://user-images.githubusercontent.com/29580620/92519223-e3500d80-f219-11ea-9055-691888e54f68.gif)
