### PR TITLE
Add 3d debug cursor and DebugPlugin

### DIFF
--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -6,6 +6,7 @@ fn main() {
         .add_resource(Msaa { samples: 4 })
         .add_default_plugins()
         .add_plugin(PickingPlugin)
+        .add_plugin(DebugPickingPlugin)
         .add_startup_system(setup.system())
         .add_startup_system(set_highlight_params.system())
         .add_system(get_picks.system())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,9 +224,7 @@ fn update_debug_cursor_position(
         let pos = top_pick.get_pick_coord_world(projection_matrix, view_matrix);
 
         for (_, mut translation) in &mut query.iter() {
-            translation.0.set_x(pos.x());
-            translation.0.set_y(pos.y());
-            translation.0.set_z(pos.z());
+            translation.0 = pos;
         }
     }
 }


### PR DESCRIPTION
As I mentioned in #21, I've created the 3d debug cursor discussed in #14. 

I've decided to create a plugin called `DebugPickingPlugin` which sets everything up, where future debug tools can be added. This way all the debug stuff can be added easily and independently from the main plugin. I think this is the cleanest approach, what do you think?