### PR TITLE
Add docs for getting World Position in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you also want to select meshes and keep them highlighted with the left mouse 
 
 #### Pick Intersections Under the Cursor
 
-Mesh picking intersection are reported in [NDC](http://www.songho.ca/opengl/gl_projectionmatrix.html). You can use the `PickState` resource to either get the topmost entity, or a list of all entities sorted by distance (near -> far) under the cursor:
+Mesh picking intersection are reported in [NDC](http://www.songho.ca/opengl/gl_projectionmatrix.html) and World Coordinates. You can use the `PickState` resource to either get the topmost entity, or a list of all entities sorted by distance (near -> far) under the cursor:
 
 ```rust
 fn get_picks(
@@ -83,6 +83,33 @@ fn get_picks(
 ```
 
 Alternatively, you can create a query to iterate over all `PickableMesh`s and get the entity's pick coordinates with `get_pick_coord_ndc()`.
+
+#### World coordinates
+
+You can get the pick world coordinates with the `get_pick_coord_world()` function in the `PickIntersection` returned from `pick_state.top()`. You will have to pass in your camera's `projection_matrix` and `view_matrix`:
+
+```rust
+fn get_world_coords(
+    pick_state: ResMut<PickState>,
+    mut query: Query<(&DebugCursor, &mut Translation)>,
+    mut camera_query: Query<(&Transform, &Camera)>,
+) {
+    // Get the camera
+    let mut view_matrix = Mat4::zero();
+    let mut projection_matrix = Mat4::zero();
+    for (transform, camera) in &mut camera_query.iter() {
+        view_matrix = transform.value.inverse();
+        projection_matrix = camera.projection_matrix;
+    }
+
+    // Get the top pick's world position
+    if let Some(top_pick) = pick_state.top() {
+        let world_position: Vec3 = top_pick.get_pick_coord_world(projection_matrix, view_matrix);
+
+        // Do something with world_pos...
+    }
+}
+```
 
 #### Selection State
 


### PR DESCRIPTION
Some people in the [Bevy discord](https://discordapp.com/channels/691052431525675048/742884593551802431/753358313151922247) didn't know that World position is provided in this plugin, which made me realize that there isn't anywhere in the Readme where it's explained.

This PR adds a short explanation, with a function example copied from the 3d cursor in #22.

Feel free to suggest any changes, I'm not sure how you prefer the docs to be.