### PR TITLE
Add Entity getter to PickIntersection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,10 @@ impl PickIntersection {
             distance,
         }
     }
+    /// Entity intersected with
+    pub fn entity(&self) -> Entity {
+        self.entity
+    }
     /// Position vector describing the intersection position.
     pub fn position(&self) -> &Vec3 {
         self.intersection.origin()


### PR DESCRIPTION
After #26, I'm opening two PRs with some small changes I've been trying on my [develop](https://github.com/guimcaballero/bevy_mod_picking/tree/develop) branch.

This one adds simply an entity getter to PickIntersection. Just a question about naming, should it be `get_entity()` or just `entity()`? 