### PR TITLE
Update transforms after rework in bevy#374

### DIFF
--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -35,7 +35,7 @@ fn setup(
         .spawn(PbrComponents {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
-            translation: Translation::new(0.0, 1.0, 0.0),
+            transform: Transform::from_translation(Vec3::new(0.0, 1.0, 0.0)),
             ..Default::default()
         })
         .with(PickableMesh::new(camera_entity))
@@ -48,7 +48,7 @@ fn setup(
                 radius: 0.5,
             })),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
-            translation: Translation::new(1.5, 1.5, 1.5),
+            transform: Transform::from_translation(Vec3::new(1.5, 1.5, 1.5)),
             ..Default::default()
         })
         .with(PickableMesh::new(camera_entity))
@@ -56,14 +56,14 @@ fn setup(
         .with(SelectablePickMesh::new())
         // light
         .spawn(LightComponents {
-            translation: Translation::new(4.0, 8.0, 4.0),
+            transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
             ..Default::default()
         })
         // camera
         .spawn_as_entity(
             camera_entity,
             Camera3dComponents {
-                transform: Transform::new_sync_disabled(Mat4::face_toward(
+                transform: Transform::new(Mat4::face_toward(
                     Vec3::new(-3.0, 5.0, 8.0),
                     Vec3::new(0.0, 0.0, 0.0),
                     Vec3::new(0.0, 1.0, 0.0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,9 +182,9 @@ fn update_debug_cursor_position(
         } else {
             Quat::default()
         };
+        let transform_new = Mat4::from_rotation_translation(new_rotation, *position);
         for mut transform in &mut query.iter() {
-            transform.set_translation(*position);
-            transform.set_rotation(new_rotation);
+            *transform.value_mut() = transform_new;
         }
     }
 }


### PR DESCRIPTION
PR [#374](https://github.com/bevyengine/bevy/pull/374) changed how transforms work on bevy. This PR updates everything to be up to date.

Currently there's an issue I haven't been able to fix:

![bevy](https://user-images.githubusercontent.com/29580620/93268266-2b88a600-f7ad-11ea-8ce8-856eab7566d1.gif)

The cursor jumps around when on the ball, but not on the cube or the plane. 

I'll try to fix it tomorrow, but if you see what I'm doing wrong please let me know.