### PR TITLE
Index buffer specialization (Bevy PR #568)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["game-engines", "rendering"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "^0.2.1"
-#bevy = { git = "https://github.com/bevyengine/bevy", branch = "master" }
+#bevy = "^0.2.1"
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "master" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,7 @@ fn pick_mesh(
 
 fn ray_mesh_intersection<T: TryInto<usize> + Copy>(
     mesh_to_world: &Mat4,
-    vertex_positions: &Vec<[f32; 3]>,
+    vertex_positions: &[[f32; 3]],
     pick_ray: &Ray3d,
     entity: Entity,
     indices: &[T],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,9 +442,12 @@ fn ray_mesh_intersection<T: TryInto<usize> + Copy>(
             // Construct a triangle in world space using the mesh data
             let mut world_vertices: [Vec3; 3] = [Vec3::zero(), Vec3::zero(), Vec3::zero()];
             for i in 0..3 {
-                let vertex_index = index[i].try_into().unwrap_or_default();
-                world_vertices[i] =
-                    mesh_to_world.transform_point3(Vec3::from(vertex_positions[vertex_index]));
+                if let Ok(vertex_index) = index[i].try_into() {
+                    world_vertices[i] =
+                        mesh_to_world.transform_point3(Vec3::from(vertex_positions[vertex_index]));
+                } else {
+                    panic!("Failed to convert index into usize.");
+                }
             }
             let world_triangle = Triangle::from(world_vertices);
             // Run the raycast on the ray and triangle

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,7 +382,7 @@ fn pick_mesh(
 
                     match indices {
                         Indices::U16(vector) => {
-                            for index in indices.chunks(3) {
+                            for index in vector.chunks(3) {
                                 // Make sure this chunk has 3 vertices to avoid a panic.
                                 if index.len() != 3 {
                                     break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,7 +426,7 @@ fn ray_mesh_intersection<T: TryInto<usize> + Copy>(
     vertex_positions: &Vec<[f32; 3]>,
     pick_ray: &Ray3d,
     entity: Entity,
-    indices: &Vec<T>,
+    indices: &[T],
 ) -> Option<PickIntersection> {
     // The ray cast can hit the same mesh many times, so we need to track which hit is
     // closest to the camera, and record that.

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -1,6 +1,6 @@
 use bevy::{
     prelude::*,
-    render::mesh::{VertexAttribute, VertexAttributeValues},
+    render::mesh::{Indices, VertexAttribute, VertexAttributeValues},
     render::pipeline::PrimitiveTopology,
 };
 
@@ -111,10 +111,20 @@ impl From<&Mesh> for BoundingSphere {
             }
         }
         if let Some(indices) = &mesh.indices {
-            for index in indices.iter() {
-                mesh_radius =
-                    mesh_radius.max(Vec3::from(vertex_positions[*index as usize]).length());
-            }
+            match indices {
+                Indices::U16(vector) => {
+                    for index in vector.iter() {
+                        mesh_radius =
+                            mesh_radius.max(Vec3::from(vertex_positions[*index as usize]).length());
+                    }
+                }
+                Indices::U32(vector) => {
+                    for index in vector.iter() {
+                        mesh_radius =
+                            mesh_radius.max(Vec3::from(vertex_positions[*index as usize]).length());
+                    }
+                }
+            };
         }
         BoundingSphere {
             mesh_radius,


### PR DESCRIPTION
Bevy PR [#568](https://github.com/bevyengine/bevy/pull/568) reworked mesh indices, this PR introduces a fix to deal with that.

There's one thing I don't like of my implementation, because we would now have the same code twice and that's a big no no.

The other option is to use something like this above the `for index in indices.chunks(3)` loop:

```rust
let indices: Vec<usize> = match indices {
                        Indices::U16(vector) => {
                            vector.iter().map(|index| *index as usize).collect()
                        }
                        Indices::U32(vector) => {
                            vector.iter().map(|index| *index as usize).collect()
                        }
                    };
```

But as far as I know this would make a copy of the whole indices vector, and that doesn't seem right either.

Any ideas on how to do this in a more idiomatic way I'm not seeing?