### PR TITLE
Update for compatibility with Bevy 0.2

### DIFF
--- a/examples/interactable_cube.rs
+++ b/examples/interactable_cube.rs
@@ -64,8 +64,8 @@ fn setup(
         });
 }
 
-fn interactable_demo(mut imesh_entities: Query<&InteractableMesh>) {
-    for imesh in imesh_entities.iter().iter() {
+fn interactable_demo(imesh_entities: Query<&InteractableMesh>) {
+    for imesh in imesh_entities.iter() {
         if imesh.mouse_hover {
             //println!("Hovering!");
         }
@@ -78,19 +78,16 @@ fn interactable_demo(mut imesh_entities: Query<&InteractableMesh>) {
             println!("Mouse Exited");
         }
 
-        match imesh.mouse_down(MouseButton::Left) {
-            Some(v) => println!("Left Mouse Button is Down"),
-            None => (),
+        if imesh.mouse_down(MouseButton::Left).is_some() {
+            println!("Left Mouse Button is Down");
         }
 
-        match imesh.mouse_just_pressed(MouseButton::Left) {
-            Some(v) => println!("Left Mouse just Clicked"),
-            None => (),
+        if imesh.mouse_just_pressed(MouseButton::Left).is_some() {
+            println!("Left Mouse just Clicked");
         }
 
-        match imesh.mouse_just_released(MouseButton::Left) {
-            Some(v) => println!("Left Mouse just Released"),
-            None => (),
+        if imesh.mouse_just_released(MouseButton::Left).is_some() {
+            println!("Left Mouse just Released");
         }
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -46,15 +46,15 @@ fn update_debug_cursor_position(
     // Set the cursor translation to the top pick's world coordinates
     for (_group, top_pick) in pick_state.top_all() {
         let transform_new = top_pick.intersection.to_transform();
-        for mut transform in &mut query.iter() {
+        for mut transform in &mut query.iter_mut() {
             *transform = Transform::from_matrix(transform_new);
         }
-        for mut draw in &mut visibility_query.iter() {
+        for mut draw in &mut visibility_query.iter_mut() {
             draw.is_visible = true;
         }
     }
     if pick_state.top_all().is_empty() {
-        for mut draw in &mut visibility_query.iter() {
+        for mut draw in &mut visibility_query.iter_mut() {
             draw.is_visible = false;
         }
     }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -72,10 +72,10 @@ pub fn pick_highlighting(
         &SelectablePickMesh,
         &Handle<StandardMaterial>,
     )>,
-    mut query_selectables: Query<&SelectablePickMesh>,
+    query_selectables: Query<&SelectablePickMesh>,
 ) {
     // Query selectable entities that have changed
-    for (mut highlightable, selectable, material_handle) in &mut query_selected.iter() {
+    for (mut highlightable, selectable, material_handle) in &mut query_selected.iter_mut() {
         let current_color = &mut materials.get_mut(material_handle).unwrap().albedo;
         let initial_color = match highlightable.initial_color {
             None => {
@@ -92,7 +92,7 @@ pub fn pick_highlighting(
     }
 
     // Query highlightable entities that have changed
-    for (mut highlightable, _pickable, material_handle, entity) in &mut query_picked.iter() {
+    for (mut highlightable, _pickable, material_handle, entity) in &mut query_picked.iter_mut() {
         let current_color = &mut materials.get_mut(material_handle).unwrap().albedo;
         let initial_color = match highlightable.initial_color {
             None => {
@@ -110,13 +110,9 @@ pub fn pick_highlighting(
         }
         if topmost {
             *current_color = highlight_params.hover_color;
-        } else if let Ok(mut query) = query_selectables.entity(entity) {
-            if let Some(selectable) = query.get() {
-                if selectable.selected() {
-                    *current_color = highlight_params.selection_color;
-                } else {
-                    *current_color = initial_color;
-                }
+        } else if let Ok(selectable) = query_selectables.get(entity) {
+            if selectable.selected() {
+                *current_color = highlight_params.selection_color;
             }
         } else {
             *current_color = initial_color;

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -57,22 +57,14 @@ impl Default for HighlightablePickMesh {
 /// appropriate materials...
 pub fn pick_highlighting(
     // Resources
-    pick_state: Res<PickState>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     highlight_params: Res<PickHighlightParams>,
     // Queries
-    mut query_picked: Query<(
-        &mut HighlightablePickMesh,
-        &PickableMesh,
-        &Handle<StandardMaterial>,
-        Entity,
-    )>,
     mut query_selected: Query<(
         &mut HighlightablePickMesh,
         &SelectablePickMesh,
         &Handle<StandardMaterial>,
     )>,
-    query_selectables: Query<&SelectablePickMesh>,
 ) {
     // Query selectable entities that have changed
     for (mut highlightable, selectable, material_handle) in &mut query_selected.iter_mut() {
@@ -90,7 +82,24 @@ pub fn pick_highlighting(
             *current_color = initial_color;
         }
     }
+}
 
+/// Given the current selected meshes and provided materials, update the meshes with the
+/// appropriate materials...
+pub fn pick_selecting(
+    // Resources
+    pick_state: Res<PickState>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    highlight_params: Res<PickHighlightParams>,
+    // Queries
+    mut query_picked: Query<(
+        &mut HighlightablePickMesh,
+        &PickableMesh,
+        &Handle<StandardMaterial>,
+        Entity,
+    )>,
+    query_selectables: Query<&SelectablePickMesh>,
+) {
     // Query highlightable entities that have changed
     for (mut highlightable, _pickable, material_handle, entity) in &mut query_picked.iter_mut() {
         let current_color = &mut materials.get_mut(material_handle).unwrap().albedo;

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -57,41 +57,11 @@ impl Default for HighlightablePickMesh {
 /// appropriate materials...
 pub fn pick_highlighting(
     // Resources
-    mut materials: ResMut<Assets<StandardMaterial>>,
-    highlight_params: Res<PickHighlightParams>,
-    // Queries
-    mut query_selected: Query<(
-        &mut HighlightablePickMesh,
-        &SelectablePickMesh,
-        &Handle<StandardMaterial>,
-    )>,
-) {
-    // Query selectable entities that have changed
-    for (mut highlightable, selectable, material_handle) in &mut query_selected.iter_mut() {
-        let current_color = &mut materials.get_mut(material_handle).unwrap().albedo;
-        let initial_color = match highlightable.initial_color {
-            None => {
-                highlightable.initial_color = Some(*current_color);
-                *current_color
-            }
-            Some(color) => color,
-        };
-        if selectable.selected() {
-            *current_color = highlight_params.selection_color;
-        } else {
-            *current_color = initial_color;
-        }
-    }
-}
-
-/// Given the current selected meshes and provided materials, update the meshes with the
-/// appropriate materials...
-pub fn pick_selecting(
-    // Resources
     pick_state: Res<PickState>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     highlight_params: Res<PickHighlightParams>,
     // Queries
+    mut query_selected: Query<(&SelectablePickMesh, &Handle<StandardMaterial>)>,
     mut query_picked: Query<(
         &mut HighlightablePickMesh,
         &PickableMesh,
@@ -100,6 +70,14 @@ pub fn pick_selecting(
     )>,
     query_selectables: Query<&SelectablePickMesh>,
 ) {
+    // Query selectable entities that have changed
+    for (selectable, material_handle) in &mut query_selected.iter_mut() {
+        let current_color = &mut materials.get_mut(material_handle).unwrap().albedo;
+        if selectable.selected() {
+            *current_color = highlight_params.selection_color;
+        }
+    }
+
     // Query highlightable entities that have changed
     for (mut highlightable, _pickable, material_handle, entity) in &mut query_picked.iter_mut() {
         let current_color = &mut materials.get_mut(material_handle).unwrap().albedo;

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -122,6 +122,8 @@ pub fn pick_selecting(
         } else if let Ok(selectable) = query_selectables.get(entity) {
             if selectable.selected() {
                 *current_color = highlight_params.selection_color;
+            } else {
+                *current_color = initial_color;
             }
         } else {
             *current_color = initial_color;

--- a/src/interactable.rs
+++ b/src/interactable.rs
@@ -92,8 +92,7 @@ pub fn cursor_events(
 ) {
     //Go through the pick state and find the
     q_imesh
-        .iter()
-        .iter()
+        .iter_mut()
         .for_each(|mut element| match pickstate.top(element.0.pick_group) {
             Some(v) => process_pick((&mut element.0, element.1), v, &mouse_inputs),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,7 @@ impl Plugin for PickingPlugin {
             .add_system(pick_mesh.system())
             .add_system(cursor_events.system())
             .add_system(select_mesh.system())
-            .add_system(pick_highlighting.system())
-            .add_system(pick_selecting.system());
+            .add_system(pick_highlighting.system());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,8 @@ impl Plugin for PickingPlugin {
             .add_system(pick_mesh.system())
             .add_system(cursor_events.system())
             .add_system(select_mesh.system())
-            .add_system(pick_highlighting.system());
+            .add_system(pick_highlighting.system())
+            .add_system(pick_selecting.system());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use bevy::{
     prelude::*,
     render::{
         camera::Camera,
-        mesh::{Indices, VertexAttribute, VertexAttributeValues},
+        mesh::{Indices, Mesh, VertexAttributeValues},
         pipeline::PrimitiveTopology,
     },
     window::{CursorMoved, WindowId},
@@ -213,7 +213,7 @@ fn build_rays(
     }
 
     // Generate a ray for each picking source based on the pick method
-    for (mut pick_source, transform, camera_opt) in &mut pick_source_query.iter() {
+    for (mut pick_source, transform, camera_opt) in &mut pick_source_query.iter_mut() {
         let group_number = match pick_source.group {
             PickGroup::Group(n) => n,
             PickGroup::Disabled => continue,
@@ -332,7 +332,7 @@ fn pick_mesh(
     mut pick_state: ResMut<PickState>,
     meshes: Res<Assets<Mesh>>,
     // Queries
-    mut mesh_query: Query<(
+    mesh_query: Query<(
         &Handle<Mesh>,
         &GlobalTransform,
         &PickableMesh,
@@ -383,8 +383,8 @@ fn pick_mesh(
             let vertex_positions: Vec<[f32; 3]> = mesh
                 .attributes
                 .iter()
-                .filter(|attribute| attribute.name == VertexAttribute::POSITION)
-                .filter_map(|attribute| match &attribute.values {
+                .filter(|attribute| attribute.0 == Mesh::ATTRIBUTE_POSITION)
+                .filter_map(|attribute| match &attribute.1 {
                     VertexAttributeValues::Float3(positions) => Some(positions.clone()),
                     _ => panic!("Unexpected vertex types in VertexAttribute::POSITION"),
                 })

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -1,6 +1,6 @@
 use bevy::{
     prelude::*,
-    render::mesh::{Indices, VertexAttribute, VertexAttributeValues},
+    render::mesh::{Indices, Mesh, VertexAttributeValues},
     render::pipeline::PrimitiveTopology,
 };
 
@@ -103,8 +103,8 @@ impl From<&Mesh> for BoundingSphere {
         }
         let mut vertex_positions = Vec::new();
         for attribute in mesh.attributes.iter() {
-            if attribute.name == VertexAttribute::POSITION {
-                vertex_positions = match &attribute.values {
+            if attribute.0 == Mesh::ATTRIBUTE_POSITION {
+                vertex_positions = match &attribute.1 {
                     VertexAttributeValues::Float3(positions) => positions.clone(),
                     _ => panic!("Unexpected vertex types in VertexAttribute::POSITION"),
                 };

--- a/src/select.rs
+++ b/src/select.rs
@@ -33,12 +33,12 @@ pub fn select_mesh(
 ) {
     if mouse_button_inputs.just_pressed(MouseButton::Left) {
         // Deselect everything
-        for mut selectable in &mut query.iter() {
+        for mut selectable in &mut query.iter_mut() {
             selectable.selected = false;
         }
 
         for (_group, pick) in pick_state.top_all() {
-            if let Ok(mut top_mesh) = query.get_mut::<SelectablePickMesh>(pick.entity) {
+            if let Ok(mut top_mesh) = query.get_mut(pick.entity) {
                 top_mesh.selected = true;
                 break;
             }


### PR DESCRIPTION
This PR includes a number of small changes to realign with the new bevy master, including:
- Update use of `VertexAttribute` to the new `Map` structure
- Simplify query iterators as they've been converted to real iterators (we don't need `to_iter().to_iter()` anymore)
- Migrate usages of `query.entity` and `query.component` to `query.get` and `query.get_component`
- Split pick_highlighting into two systems to avoid conflicting queries:
![Screen Shot 2020-11-02 at 4 36 52 PM](https://user-images.githubusercontent.com/2264338/97827593-9ecc8400-1d29-11eb-8db7-a9ce469ec49b.png)

