### PR TITLE
Update to Bevy master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["game-engines", "rendering"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "^0.3"
-#bevy = { git = "https://github.com/bevyengine/bevy", branch = "master" }
+# bevy = "^0.3"
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "master" }

--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -8,21 +8,21 @@ fn main() {
         .add_plugin(PickingPlugin)
         .add_plugin(DebugPickingPlugin)
         .add_plugin(InteractablePickingPlugin)
-        .add_startup_system(setup.system())
-        .add_startup_system(set_highlight_params.system())
+        .add_startup_system(setup)
+        .add_startup_system(set_highlight_params)
         .run();
 }
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    commands: &mut Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // add entities to the world
     // camera
     commands
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(-3.0, 5.0, 8.0),
                 Vec3::new(0.0, 0.0, 0.0),
@@ -32,7 +32,7 @@ fn setup(
         })
         .with(PickSource::default())
         //plane
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Plane { size: 10.0 })),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             ..Default::default()
@@ -42,7 +42,7 @@ fn setup(
         .with(HighlightablePickMesh::default())
         .with(SelectablePickMesh::default())
         // cube
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             transform: Transform::from_translation(Vec3::new(0.0, 1.0, 0.0)),
@@ -53,7 +53,7 @@ fn setup(
         .with(HighlightablePickMesh::default())
         .with(SelectablePickMesh::default())
         // sphere
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Icosphere {
                 subdivisions: 4,
                 radius: 0.5,
@@ -67,7 +67,7 @@ fn setup(
         .with(HighlightablePickMesh::default())
         .with(SelectablePickMesh::default())
         // light
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
             ..Default::default()
         });

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -7,20 +7,20 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(PickingPlugin)
         .add_plugin(InteractablePickingPlugin)
-        .add_startup_system(setup.system())
-        .add_system(event_example.system())
+        .add_startup_system(setup)
+        .add_system(event_example)
         .run();
 }
 
 fn setup(
-    mut commands: Commands,
+    commands: &mut Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // add entities to the world
     commands
         // camera
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(-3.0, 5.0, 8.0),
                 Vec3::new(0.0, 0.0, 0.0),
@@ -30,7 +30,7 @@ fn setup(
         })
         .with(PickSource::default())
         //plane
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Plane { size: 10.0 })),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             ..Default::default()
@@ -38,7 +38,7 @@ fn setup(
         .with(PickableMesh::default())
         .with(InteractableMesh::default())
         // cube
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             transform: Transform::from_translation(Vec3::new(0.0, 1.0, 0.0)),
@@ -47,7 +47,7 @@ fn setup(
         .with(PickableMesh::default())
         .with(InteractableMesh::default())
         // light
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
             ..Default::default()
         });

--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -20,12 +20,12 @@ fn main() {
         .add_plugin(PickingPlugin)
         .add_plugin(DebugPickingPlugin)
         .add_plugin(InteractablePickingPlugin)
-        .add_startup_system(setup.system())
+        .add_startup_system(setup)
         .run();
 }
 
 fn setup(
-    mut commands: Commands,
+    commands: &mut Commands,
     mut create_window_events: ResMut<Events<CreateWindow>>,
     mut active_cameras: ResMut<ActiveCameras>,
     mut render_graph: ResMut<RenderGraph>,
@@ -171,7 +171,7 @@ fn setup(
     // add entities to the world
     commands
         // mesh
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: mesh_handle,
             material: material_handle,
             ..Default::default()
@@ -181,12 +181,12 @@ fn setup(
         .with(HighlightablePickMesh::default())
         .with(SelectablePickMesh::default())
         // light
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(4.0, 5.0, 4.0)),
             ..Default::default()
         })
         // main camera
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(0.0, 0.0, 6.0),
                 Vec3::new(0.0, 0.0, 0.0),
@@ -199,7 +199,7 @@ fn setup(
             PickMethod::CameraCursor(WindowId::primary()),
         ))
         // second window camera
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             camera: Camera {
                 name: Some("Secondary".to_string()),
                 window: window_id,

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -12,13 +12,13 @@ fn main() {
         .add_plugin(DebugPickingPlugin)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(PrintDiagnosticsPlugin::default())
-        .add_startup_system(setup.system())
+        .add_startup_system(setup)
         .run();
 }
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    commands: &mut Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -32,7 +32,7 @@ fn setup(
 
     // camera
     commands
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(-3.0, 5.0, 8.0),
                 Vec3::new(0.0, 0.0, 0.0),
@@ -45,7 +45,7 @@ fn setup(
     for i in 0..edge_length.pow(3) {
         let f_edge_length = edge_length as f32;
         let _a = commands
-            .spawn(PbrComponents {
+            .spawn(PbrBundle {
                 mesh: meshes.add(Mesh::from(shape::Icosphere {
                     radius: 0.25,
                     subdivisions: subdivision,
@@ -64,7 +64,7 @@ fn setup(
             .with(SelectablePickMesh::default());
     }
 
-    commands.spawn(LightComponents {
+    commands.spawn(LightBundle {
         transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
         ..Default::default()
     });

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,9 +5,9 @@ pub struct DebugPickingPlugin;
 impl Plugin for DebugPickingPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.init_resource::<CursorEvents>()
-            .add_startup_system(setup_debug_cursor.system())
-            .add_system(update_debug_cursor_position.system())
-            .add_system(get_picks.system());
+            .add_startup_system(setup_debug_cursor)
+            .add_system(update_debug_cursor_position)
+            .add_system(get_picks);
     }
 }
 
@@ -40,8 +40,8 @@ struct DebugCursorMesh;
 /// Updates the 3d cursor to be in the pointed world coordinates
 fn update_debug_cursor_position(
     pick_state: Res<PickState>,
-    mut query: Query<With<DebugCursor, &mut Transform>>,
-    mut visibility_query: Query<With<DebugCursorMesh, &mut Draw>>,
+    mut query: Query<&mut Transform, With<DebugCursor>>,
+    mut visibility_query: Query<&mut Draw, With<DebugCursorMesh>>,
 ) {
     // Set the cursor translation to the top pick's world coordinates
     match pick_state.top_all() {
@@ -66,7 +66,7 @@ fn update_debug_cursor_position(
 
 /// Start up system to create 3d Debug cursor
 fn setup_debug_cursor(
-    mut commands: Commands,
+    commands: &mut Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -80,7 +80,7 @@ fn setup_debug_cursor(
     let ball_size = 0.08;
     commands
         // cursor
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Icosphere {
                 subdivisions: 4,
                 radius: ball_size,
@@ -95,7 +95,7 @@ fn setup_debug_cursor(
 
             // child cube
             parent
-                .spawn(PbrComponents {
+                .spawn(PbrBundle {
                     mesh: meshes.add(Mesh::from(shape::Cube { size: cube_size })),
                     material: debug_matl,
                     transform,

--- a/src/interactable.rs
+++ b/src/interactable.rs
@@ -5,10 +5,10 @@ use std::collections::HashSet;
 pub struct InteractablePickingPlugin;
 impl Plugin for InteractablePickingPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.add_system(generate_hover_events.system())
-            .add_system(generate_click_events.system())
-            .add_system(select_mesh.system())
-            .add_system(pick_highlighting.system());
+        app.add_system(generate_hover_events)
+            .add_system(generate_click_events)
+            .add_system(select_mesh)
+            .add_system(pick_highlighting);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ impl Plugin for PickingPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.init_resource::<PickState>()
             .init_resource::<PickHighlightParams>()
-            .add_system(build_rays.system())
-            .add_system(pick_mesh.system());
+            .add_system(build_rays)
+            .add_system(pick_mesh);
     }
 }
 


### PR DESCRIPTION
This PR fixes some stuff changed in Bevy master, namely: 

- `mut commands: Commands` into `commands: &mut Commands`.
- `XComponents` into `XBundle`.
- `Query<With<X, Y>>` into `Query<Y, With<X>>`.
- Removing `.system()` when registering systems.
