### PR TITLE
Added option to always update the mouse picking via saving the last m…

### DIFF
--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -39,8 +39,8 @@ fn setup(
     create_window_events.send(CreateWindow {
         id: window_id,
         descriptor: WindowDescriptor {
-            width: 800,
-            height: 600,
+            width: 800.0,
+            height: 600.0,
             vsync: false,
             title: "second window".to_string(),
             ..Default::default()
@@ -196,7 +196,7 @@ fn setup(
         })
         .with(PickSource::new(
             [Group(0)].into(),
-            PickMethod::CameraCursor(WindowId::primary()),
+            PickMethod::CameraCursor(WindowId::primary(), UpdatePicks::Always),
         ))
         // second window camera
         .spawn(Camera3dBundle {
@@ -214,6 +214,6 @@ fn setup(
         })
         .with(PickSource::new(
             [Group(1)].into(),
-            PickMethod::CameraCursor(window_id),
+            PickMethod::CameraCursor(window_id, UpdatePicks::Always),
         ));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,12 +274,12 @@ fn build_rays(
                         }
                     }
                     None => {
-                      if (pick_source.always_on) {
-                        pick_state.last_cursor_pos
-                      } else {
-                        continue
-                      }
-                    },
+                        if (pick_source.always_on) {
+                            pick_state.last_cursor_pos
+                        } else {
+                            continue;
+                        }
+                    }
                 };
                 pick_state.last_cursor_pos = cursor_pos_screen;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,16 +277,12 @@ fn build_rays(
                             continue;
                         }
                     }
-                    None => {
-                        match update_picks {
-                            UpdatePicks::Always => {
-                                pick_state.last_cursor_pos
-                            }
-                            UpdatePicks::OnMouseEvent => {
-                                continue;
-                            }
+                    None => match update_picks {
+                        UpdatePicks::Always => pick_state.last_cursor_pos,
+                        UpdatePicks::OnMouseEvent => {
+                            continue;
                         }
-                    }
+                    },
                 };
                 pick_state.last_cursor_pos = cursor_pos_screen;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ fn build_rays(
                         }
                     }
                     None => {
-                        if (pick_source.always_on) {
+                        if pick_source.always_on {
                             pick_state.last_cursor_pos
                         } else {
                             continue;


### PR DESCRIPTION
Hi! We implemented the ff:
- Added option to always update the mouse picking even when mouse is not moved via saving the last mouse position
- By default it is false.
- Snippet to set as always_on:
`.with(PickSource {
      always_on: true,
      ..Default::default()
    })`
- Solves issues: https://github.com/aevyrie/bevy_mod_picking/issues/64 and https://github.com/aevyrie/bevy_mod_picking/issues/67