### PR TITLE
disable bevy default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["game-engines", "rendering"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# bevy = "^0.3"
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "master" }
+# bevy = { version = "^0.3", default-features = false, features = ["render"] }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "master", default-features = false, features = ["render"] }

--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -39,8 +39,8 @@ fn setup(
     create_window_events.send(CreateWindow {
         id: window_id,
         descriptor: WindowDescriptor {
-            width: 800,
-            height: 600,
+            width: 800.0,
+            height: 600.0,
             vsync: false,
             title: "second window".to_string(),
             ..Default::default()


### PR DESCRIPTION
this speeds up compile time, and allow usage of this library in a wasm build