### PR TITLE
add features for examples after disabling bevy default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,19 @@ categories = ["game-engines", "rendering"]
 [dependencies]
 # bevy = { version = "^0.3", default-features = false, features = ["render"] }
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "master", default-features = false, features = ["render"] }
+
+[[example]]
+name = "3d_scene"
+required-features = [ "bevy/bevy_wgpu", "bevy/bevy_winit" ]
+
+[[example]]
+name = "events"
+required-features = [ "bevy/bevy_wgpu", "bevy/bevy_winit" ]
+
+[[example]]
+name = "multiple_windows"
+required-features = [ "bevy/bevy_wgpu", "bevy/bevy_winit" ]
+
+[[example]]
+name = "stress_test"
+required-features = [ "bevy/bevy_wgpu", "bevy/bevy_winit" ]


### PR DESCRIPTION
forgot to add needed features for examples: https://github.com/aevyrie/bevy_mod_picking/pull/70#issuecomment-745027081

example `multiple_windows` is still panicking, but then it also does on bevy: https://github.com/bevyengine/bevy/issues/1069