### PR TITLE
Mouse picking update default

### DIFF
--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, render::camera::Camera};
 use bevy_mod_picking::*;
 
 fn main() {
@@ -8,8 +8,9 @@ fn main() {
         .add_plugin(PickingPlugin)
         .add_plugin(DebugPickingPlugin)
         .add_plugin(InteractablePickingPlugin)
-        .add_startup_system(setup)
-        .add_startup_system(set_highlight_params)
+        .add_startup_system(setup.system())
+        .add_startup_system(set_highlight_params.system())
+        .add_system(oscillation_system.system())
         .run();
 }
 
@@ -76,4 +77,10 @@ fn setup(
 fn set_highlight_params(mut highlight_params: ResMut<PickHighlightParams>) {
     highlight_params.set_hover_color(Color::rgb(1.0, 0.0, 0.0));
     highlight_params.set_selection_color(Color::rgb(1.0, 0.0, 1.0));
+}
+
+fn oscillation_system(time: Res<Time>, mut query: Query<&mut Transform, With<Camera>>) {
+    for mut transform in query.iter_mut() {
+        transform.translation.y = 5.0 + time.seconds_since_startup().sin() as f32;
+    }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -4,31 +4,14 @@ use bevy::prelude::*;
 pub struct DebugPickingPlugin;
 impl Plugin for DebugPickingPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.init_resource::<CursorEvents>()
-            .add_startup_system(setup_debug_cursor.system())
+        app.add_startup_system(setup_debug_cursor.system())
             .add_system(update_debug_cursor_position.system())
             .add_system(get_picks.system());
     }
 }
 
-pub struct CursorEvents {
-    cursor_event_reader: EventReader<CursorMoved>,
-}
-
-impl Default for CursorEvents {
-    fn default() -> Self {
-        CursorEvents {
-            cursor_event_reader: EventReader::default(),
-        }
-    }
-}
-
-fn get_picks(
-    pick_state: Res<PickState>,
-    mut cursor_events: ResMut<CursorEvents>,
-    cursor: Res<Events<CursorMoved>>,
-) {
-    if cfg!(debug_assertions) && cursor_events.cursor_event_reader.latest(&cursor).is_some() {
+fn get_picks(pick_state: Res<PickState>) {
+    if cfg!(debug_assertions) {
         println!("Top entities:\n{:#?}", pick_state.top_all())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ impl Default for PickSource {
     fn default() -> Self {
         PickSource {
             groups: Some(vec![Group::default()]),
-            pick_method: PickMethod::CameraCursor(WindowId::primary(), UpdatePicks::OnMouseEvent),
+            pick_method: PickMethod::CameraCursor(WindowId::primary(), UpdatePicks::Always),
             cursor_events: EventReader::default(),
         }
     }


### PR DESCRIPTION
Change default mouse picksource behavior to update every frame instead of only on mouse events. This resolves #67.