### PR TITLE
 Using log::trace instead of println

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -12,7 +12,7 @@ impl Plugin for DebugPickingPlugin {
 
 fn get_picks(pick_state: Res<PickState>) {
     if cfg!(debug_assertions) {
-        println!("Top entities:\n{:#?}", pick_state.top_all())
+        trace!("Top entities:\n{:#?}", pick_state.top_all())
     }
 }
 


### PR DESCRIPTION
Bevy already includes a reference to the log crate, so anyone using bevy would already have it set up.

Switching from println() to log::trace() helps those that are not using the bevy logger and are filtering log outputs.