### PR TITLE
Cursor position caching fixes

### DIFF
--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 pub use rays::*;
 
 /// Encapsulates Ray3D, preventing use of struct literal syntax. This allows us to guarantee that
-/// the `Ray3d` direction is normalized, because it can only be instantiated with the constuctor.
+/// the `Ray3d` direction is normalized, because it can only be instantiated with the constructor.
 pub mod rays {
     use bevy::prelude::*;
 


### PR DESCRIPTION
Preemptive fixes to cursor position caching. Removed the cache from the top level state, moved into only the enum that needs to store the value.