### PR TITLE
Orthographic fixes

### DIFF
--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -196,7 +196,7 @@ fn setup(
         })
         .with(PickSource::new(
             [Group(0)].into(),
-            PickMethod::CameraCursor(WindowId::primary(), UpdatePicks::Always),
+            PickMethod::CameraCursor(WindowId::primary(), UpdatePicks::Always(Vec2::default())),
         ))
         // second window camera
         .spawn(Camera3dBundle {
@@ -214,6 +214,6 @@ fn setup(
         })
         .with(PickSource::new(
             [Group(1)].into(),
-            PickMethod::CameraCursor(window_id, UpdatePicks::Always),
+            PickMethod::CameraCursor(window_id, UpdatePicks::Always(Vec2::default())),
         ));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,7 @@ fn build_rays(
 
                 let ray_direction = cursor_position - camera_position;
 
-                let pick_ray = Ray3d::new(camera_position, ray_direction);
+                let pick_ray = Ray3d::new(cursor_position, ray_direction);
 
                 for group in group_numbers {
                     if pick_state.ray_map.insert(group, pick_ray).is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,7 @@ fn build_rays(
 
                 // Normalized device coordinates (NDC) describes cursor position from (-1, -1, -1) to (1, 1, 1)
                 let cursor_pos_ndc: Vec3 =
-                    ((cursor_pos_screen / screen_size) * 2.0 - Vec2::from([1.0, 1.0])).extend(1.0);
+                    ((cursor_pos_screen / screen_size) * 2.0 - Vec2::from([1.0, 1.0])).extend(-1.0);
 
                 let camera_matrix = match transform {
                     Some(matrix) => matrix,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,9 +187,9 @@ impl Default for PickableMesh {
 /// Specifies the method used to generate pick rays
 #[derive(Debug)]
 pub enum PickMethod {
-    /// Use cursor events to get coordinatess  relative to a camera
+    /// Use cursor events to get coordinates  relative to a camera
     CameraCursor(WindowId, UpdatePicks),
-    /// Manually specify screen coordinatess relative to a camera
+    /// Manually specify screen coordinates relative to a camera
     CameraScreenSpace(Vec2),
     /// Use a tranform in world space to define pick ray
     Transform,
@@ -309,7 +309,9 @@ fn build_rays(
                 };
 
                 // Get current screen size
-                let window = windows.get(window_id).unwrap();
+                let window = windows
+                    .get(window_id)
+                    .unwrap_or_else(|| panic!("WindowId {} does not exist", window_id));
                 let screen_size = Vec2::from([window.width() as f32, window.height() as f32]);
 
                 // Normalized device coordinates (NDC) describes cursor position from (-1, -1, -1) to (1, 1, 1)
@@ -321,7 +323,7 @@ fn build_rays(
                     Some(matrix) => matrix,
                     None => panic!("The PickingSource in group(s) {:?} has a {:?} but no associated GlobalTransform component", group_numbers, pick_source.pick_method),
                 }.compute_matrix();
-                
+
                 let ndc_to_world: Mat4 = camera_matrix * projection_matrix.inverse();
                 let cursor_pos_near: Vec3 = ndc_to_world.transform_point3(cursor_pos_ndc_near);
                 let cursor_pos_far: Vec3 = ndc_to_world.transform_point3(cursor_pos_ndc_far);
@@ -340,7 +342,7 @@ fn build_rays(
                     }
                 }
             }
-            // Use the camera and specified screen cordinates to generate a ray
+            // Use the camera and specified screen coordinates to generate a ray
             PickMethod::CameraScreenSpace(coordinates_ndc) => {
                 let projection_matrix = match camera {
                     Some(camera) => camera.projection_matrix,


### PR DESCRIPTION
Changes pick ray construction for `CameraCursor` to use the ndc near and far plane, instead of the camera origin. This causes problems because with ortho projection, the view does not converge onto the camera origin. This fix means ray construction is now agnostic to projection type!