### PR TITLE
enable x11 feature for example_deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bevy = { version = "0.4", default-features = false, features = ["render"] }
 #bevy = { git = "https://github.com/bevyengine/bevy", branch = "master", default-features = false, features = ["render"] }
 
 [features]
-example_deps = [ "bevy/bevy_wgpu", "bevy/bevy_winit", "bevy/bevy_gltf" ]
+example_deps = [ "bevy/bevy_wgpu", "bevy/bevy_winit", "bevy/bevy_gltf", "bevy/x11" ]
 
 [[example]]
 name = "3d_scene"


### PR DESCRIPTION
Without it, the example would fail to compile on linux.