### PR TITLE
Expose Intersection type from bevy_mod_raycast

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::{
     mouse::update_pick_source_positions,
     selection::{mesh_selection, NoDeselect, Selection},
 };
-pub use bevy_mod_raycast::{BoundVol, Primitive3d, RayCastSource};
+pub use bevy_mod_raycast::{BoundVol, Intersection, Primitive3d, RayCastSource};
 
 use bevy::ecs::schedule::ShouldRun;
 use bevy::{prelude::*, ui::FocusPolicy};


### PR DESCRIPTION
This is the type returned by intersect_top() on PickingCamera.