### PR TITLE
Updated to bevy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_picking"
-version = "0.5.4"
+version = "0.6.0"
 authors = ["Aevyrie <aevyrie@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -14,13 +14,13 @@ resolver = "2"
 #bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
 #    "render",
 #]}
-bevy = { version = "0.6", default-features = false, features = ["render"] }
+bevy = { version = "0.7", default-features = false, features = ["render"] }
 #bevy_mod_raycast = { git = "https://github.com/aevyrie/bevy_mod_raycast", branch = "master" }
-bevy_mod_raycast = ">=0.3.9"
+bevy_mod_raycast = ">=0.4.0"
 
 [dev-dependencies]
 #bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
-bevy = { version = "0.6", default-features = false, features = [
+bevy = { version = "0.7", default-features = false, features = [
     "bevy_winit",
     "x11",
 ] }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It only takes a few lines to get mouse picking working in your Bevy application 
 
 1. Add the crate to your dependencies in `Cargo.toml`:
 ```toml
-bevy_mod_picking = "0.5"
+bevy_mod_picking = "0.6"
 ```
 
 2. Import the plugin:
@@ -67,6 +67,7 @@ I intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 |bevy|bevy_mod_picking|
 |---|---|
+|0.7|0.6|
 |0.6|0.5|
 |0.5|0.4|
 |0.4|0.3|

--- a/examples/deselection.rs
+++ b/examples/deselection.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, ui::FocusPolicy};
+use bevy::{prelude::*, ui::FocusPolicy, window::PresentMode};
 use bevy_mod_picking::{
     DefaultPickingPlugins, NoDeselect, PickableBundle, PickableButton, PickableMesh,
     PickingCameraBundle,
@@ -9,7 +9,7 @@ use bevy_mod_picking::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            vsync: false,
+            present_mode: PresentMode::Immediate,
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, window::PresentMode};
 use bevy_mod_picking::{
     DebugCursorPickingPlugin, DebugEventsPickingPlugin, DefaultPickingPlugins, PickableBundle,
     PickingCameraBundle,
@@ -7,7 +7,7 @@ use bevy_mod_picking::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            vsync: false, // Disabled for this demo to reduce input latency
+            present_mode: PresentMode::Immediate, // Disabled for this demo to reduce input latency
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -1,6 +1,7 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
+    window::PresentMode,
 };
 use bevy_mod_picking::*;
 
@@ -10,7 +11,7 @@ fn main() {
             title: "bevy_mod_picking stress test".to_string(),
             width: 800.,
             height: 600.,
-            vsync: false,
+            present_mode: PresentMode::Immediate,
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
@@ -53,7 +54,7 @@ fn setup(
     // Camera
     commands
         .spawn_bundle(PerspectiveCameraBundle {
-            transform: Transform::from_matrix(Mat4::face_toward(
+            transform: Transform::from_matrix(Mat4::look_at_rh(
                 Vec3::splat(half_width as f32),
                 Vec3::ZERO,
                 Vec3::Y,
@@ -84,7 +85,7 @@ fn setup(
 
     // Light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_matrix(Mat4::face_toward(
+        transform: Transform::from_matrix(Mat4::look_at_rh(
             Vec3::splat(half_width as f32 * 1.1),
             Vec3::ZERO,
             Vec3::Y,

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -15,9 +15,7 @@ fn main() {
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
-        .add_plugin(PickingPlugin)
-        .add_plugin(InteractablePickingPlugin)
-        .add_plugin(HighlightablePickingPlugin)
+        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction, and Highlighting plugins.
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
@@ -36,13 +34,10 @@ fn setup(
     let tris_total = tris_sphere * (half_width as usize * 2).pow(3);
     info!("Total tris: {}, Tris per mesh: {}", tris_total, tris_sphere);
 
-    let mesh_handle = meshes.add(
-        shape::Icosphere {
-            radius: 0.2,
-            subdivisions,
-        }
-        .into(),
-    );
+    let mesh_handle = meshes.add(Mesh::from(shape::Icosphere {
+        radius: 0.2,
+        subdivisions,
+    }));
 
     let matl_handle = materials.add(StandardMaterial {
         perceptual_roughness: 0.5,
@@ -54,16 +49,13 @@ fn setup(
     // Camera
     commands
         .spawn_bundle(PerspectiveCameraBundle {
-            transform: Transform::from_matrix(Mat4::look_at_rh(
-                Vec3::splat(half_width as f32),
-                Vec3::ZERO,
-                Vec3::Y,
-            )),
+            transform: Transform::from_xyz(half_width as f32, half_width as f32, half_width as f32)
+                .looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         })
         .insert_bundle(PickingCameraBundle::default());
 
-    // Spawn a huge cube of spheres.
+    // Spawn a cube of spheres.
     for x in -half_width..half_width {
         for y in -half_width..half_width {
             for z in -half_width..half_width {
@@ -85,11 +77,7 @@ fn setup(
 
     // Light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_matrix(Mat4::look_at_rh(
-            Vec3::splat(half_width as f32 * 1.1),
-            Vec3::ZERO,
-            Vec3::Y,
-        )),
+        transform: Transform::from_xyz(half_width as f32, half_width as f32, half_width as f32),
         point_light: PointLight {
             intensity: 2500.0,
             ..Default::default()

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -26,8 +26,8 @@ pub struct PickingBlocker;
 #[allow(clippy::type_complexity)]
 pub fn pause_for_picking_blockers(
     mut paused: ResMut<PausedForBlockers>,
-    mut interactions: QuerySet<(
-        QueryState<
+    mut interactions: ParamSet<(
+        Query<
             (
                 &mut Interaction,
                 Option<&mut Hover>,
@@ -37,12 +37,12 @@ pub fn pause_for_picking_blockers(
             With<PickableMesh>,
         >,
         // UI nodes are picking blockers by default.
-        QueryState<&Interaction, Or<(With<Node>, With<PickingBlocker>)>>,
+        Query<&Interaction, Or<(With<Node>, With<PickingBlocker>)>>,
     )>,
 ) {
-    for ui_interaction in interactions.q1().iter() {
+    for ui_interaction in interactions.p1().iter() {
         if *ui_interaction != Interaction::None {
-            for (mut interaction, hover, _, _) in &mut interactions.q0().iter_mut() {
+            for (mut interaction, hover, _, _) in &mut interactions.p0().iter_mut() {
                 if *interaction != Interaction::None {
                     *interaction = Interaction::None;
                 }


### PR DESCRIPTION
The biggest change affecting the code is the need to replace references to the camera's window to references to the RenderTarget.

Tested using cargo's `patch` feature using https://github.com/aevyrie/bevy_mod_raycast/pull/43.

On my machine stress_test doesn't appear to render anything. I don't know if my changes are responsible, but disabling all the non-default plugins left the scene empty.

* [ ] Merge after https://github.com/aevyrie/bevy_mod_raycast/pull/43 and after 0.4 release is done.