### PR TITLE
Family Selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_picking"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Aevyrie <aevyrie@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -11,13 +11,11 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
-    "render",
-] }
-bevy_mod_raycast = { git = "https://github.com/aevyrie/bevy_mod_raycast", branch = "main" }
+bevy = { version = "0.7", default-features = false, features = ["render"] }
+bevy_mod_raycast = "0.4.0"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+bevy = { version = "0.7", default-features = false, features = [
     "bevy_winit",
     "x11",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,10 @@ bevy = { version = "0.7", default-features = false, features = [
     "bevy_winit",
     "x11",
 ] }
+
+[features]
+family = []
+
+[[examples]]
+name = "family"
+required-features = ["family"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,3 @@ bevy = { version = "0.7", default-features = false, features = [
     "bevy_winit",
     "x11",
 ] }
-
-[features]
-family = []
-
-[[examples]]
-name = "family"
-required-features = ["family"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [dependencies]
 bevy = { version = "0.7", default-features = false, features = ["render"] }
-bevy_mod_raycast = "0.4.0"
+bevy_mod_raycast = "0.5.0"
 
 [dev-dependencies]
 bevy = { version = "0.7", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_picking"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Aevyrie <aevyrie@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# 3D Mouse Picking for Bevy
+<div align="center">
+
+# Mouse Picking for Bevy
 
 [![crates.io](https://img.shields.io/crates/v/bevy_mod_picking)](https://crates.io/crates/bevy_mod_picking)
 [![docs.rs](https://docs.rs/bevy_mod_picking/badge.svg)](https://docs.rs/bevy_mod_picking)
 [![CI](https://github.com/aevyrie/bevy_mod_picking/workflows/CI/badge.svg?branch=master)](https://github.com/aevyrie/bevy_mod_picking/actions?query=workflow%3A%22CI%22+branch%3Amaster)
 [![Bevy tracking](https://img.shields.io/badge/Bevy%20tracking-main-lightblue)](https://github.com/bevyengine/bevy/blob/main/docs/plugins_guidelines.md#main-branch-tracking)
 
-A [Bevy](https://github.com/bevyengine/bevy) plugin for 3D mouse picking, making it easy to interact
-with geometry in Bevy using a mouse or touch. This plugin is built with [`bevy_mod_raycast`](https://github.com/aevyrie/bevy_mod_raycast).
+</div>
+
+A [Bevy](https://github.com/bevyengine/bevy) plugin for mouse picking, making it easy to interact with geometry in Bevy using a mouse or touch. This plugin is built with [`bevy_mod_raycast`](https://github.com/aevyrie/bevy_mod_raycast).
 
 <br/><p align="center">
 <img src="https://user-images.githubusercontent.com/2632925/114128723-d8de1b00-98b1-11eb-9b25-812fcf6664e2.gif">
@@ -65,13 +68,13 @@ cargo run --example minimal
 
 I intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
-|bevy|bevy_mod_picking|
-|---|---|
-|0.7|0.6|
-|0.6|0.5|
-|0.5|0.4|
-|0.4|0.3|
-|0.3|0.2|
+| bevy | bevy_mod_picking |
+| ---- | ---------------- |
+| 0.7  | 0.6, 0.7         |
+| 0.6  | 0.5              |
+| 0.5  | 0.4              |
+| 0.4  | 0.3              |
+| 0.3  | 0.2              |
 
 # License
 

--- a/examples/family.rs
+++ b/examples/family.rs
@@ -1,0 +1,131 @@
+use bevy::prelude::*;
+use bevy_mod_picking::{
+    DebugCursorPickingPlugin, DebugEventsPickingPlugin, DefaultPickingPlugins, PickableBundle,
+    PickingCameraBundle,
+};
+
+fn main() {
+    App::new()
+        .insert_resource(WindowDescriptor {
+            vsync: false, // Disabled for this demo to reduce input latency
+            ..Default::default()
+        })
+        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction, and Highlighting plugins.
+        .add_plugin(DebugCursorPickingPlugin) // <- Adds the green debug cursor.
+        .add_plugin(DebugEventsPickingPlugin) // <- Adds debug event logging.
+        .add_startup_system(setup)
+        .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // plane
+    commands
+        .spawn_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+            ..Default::default()
+        })
+        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+
+    // cube
+    commands
+        .spawn_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            transform: Transform::from_xyz(-1.0, 0.5, -1.0),
+            ..Default::default()
+        })
+        .insert_bundle(PickableBundle::default()) // <- Makes the mesh pickable.
+        .with_children(|parent| {
+            parent
+                .spawn_bundle(PbrBundle {
+                    mesh: meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
+                    material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                    transform: Transform::from_xyz(-0.5, 1.0, -0.5),
+                    ..Default::default()
+                })
+                .insert_bundle(PickableBundle::default()) // <- Makes the mesh pickable.
+                .with_children(|parent| {
+                    parent
+                        .spawn_bundle(PbrBundle {
+                            mesh: meshes.add(Mesh::from(shape::Cube { size: 0.25 })),
+                            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                            transform: Transform::from_xyz(-0.5, 1.0, -0.5),
+                            ..Default::default()
+                        })
+                        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+
+                    parent
+                        .spawn_bundle(PbrBundle {
+                            mesh: meshes.add(Mesh::from(shape::Cube { size: 0.25 })),
+                            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                            transform: Transform::from_xyz(0.25, 1.0, 0.25),
+                            ..Default::default()
+                        })
+                        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+                });
+
+            parent
+                .spawn_bundle(PbrBundle {
+                    mesh: meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
+                    material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                    transform: Transform::from_xyz(0.25, 1.0, 0.25),
+                    ..Default::default()
+                })
+                .insert_bundle(PickableBundle::default()) // <- Makes the mesh pickable.
+                .with_children(|parent| {
+                    parent
+                        .spawn_bundle(PbrBundle {
+                            mesh: meshes.add(Mesh::from(shape::Cube { size: 0.25 })),
+                            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                            transform: Transform::from_xyz(-0.25, 1.0, -0.25),
+                            ..Default::default()
+                        })
+                        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+
+                    parent
+                        .spawn_bundle(PbrBundle {
+                            mesh: meshes.add(Mesh::from(shape::Cube { size: 0.25 })),
+                            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                            transform: Transform::from_xyz(0.25, 1.0, 0.25),
+                            ..Default::default()
+                        })
+                        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+                });
+        });
+
+    // cube
+    commands
+        .spawn_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            transform: Transform::from_xyz(1.0, 0.5, 1.0),
+            ..Default::default()
+        })
+        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+
+    // light
+    commands.spawn_bundle(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..Default::default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+
+    // camera
+    commands
+        .spawn_bundle(PerspectiveCameraBundle {
+            transform: Transform::from_xyz(-4.0, 5.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..Default::default()
+        })
+        .insert_bundle(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
+}

--- a/examples/family.rs
+++ b/examples/family.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_mod_picking::{
     DebugCursorPickingPlugin, DebugEventsPickingPlugin, DefaultPickingPlugins, PickableBundle,
-    PickingCameraBundle,
+    PickingCameraBundle, FamilyPickingPlugin,
 };
 
 fn main() {
@@ -14,6 +14,7 @@ fn main() {
         .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction, and Highlighting plugins.
         .add_plugin(DebugCursorPickingPlugin) // <- Adds the green debug cursor.
         .add_plugin(DebugEventsPickingPlugin) // <- Adds debug event logging.
+        .add_plugin(FamilyPickingPlugin) // <- Adds full hierarchy selection
         .add_startup_system(setup)
         .run();
 }

--- a/examples/family.rs
+++ b/examples/family.rs
@@ -6,10 +6,7 @@ use bevy_mod_picking::{
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
-            vsync: false, // Disabled for this demo to reduce input latency
-            ..Default::default()
-        })
+        .insert_resource(WindowDescriptor::default())
         .add_plugins(DefaultPlugins)
         .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction, and Highlighting plugins.
         .add_plugin(DebugCursorPickingPlugin) // <- Adds the green debug cursor.

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -124,13 +124,16 @@ pub fn mesh_focus(
             }
         }
 
+        #[cfg(feature = "family")]
         let mut family: HashSet<Entity> = HashSet::default();
-        let mut family_interaction = None;
+        #[cfg(feature = "family")]
+        let mut family_interaction: Option<Interaction> = None;
+        #[cfg(feature = "family")]
         if let Some(entity) = hovered_entity {
             let mut visit = vec![entity];
 
             if let Ok((interaction, _, _, _, _, _)) = interactions.get(entity) {
-                family_interaction = Some(interaction);
+                family_interaction = Some(*interaction);
             }
 
             // Visit "family members" by popping them off of a queue
@@ -161,17 +164,23 @@ pub fn mesh_focus(
         }
 
         for (mut interaction, hover, _, _, _, entity) in &mut interactions.iter_mut() {
-            if !family.contains(&entity) && *interaction == Interaction::Hovered {
+            #[cfg(feature = "family")]
+            let relevant = family.contains(&entity);
+            #[cfg(not(feature = "family"))]
+            let relevant = Some(entity) == hovered_entity;
+
+            if !relevant && *interaction == Interaction::Hovered {
                 *interaction = Interaction::None;
             }
-            if family.contains(&entity) {
+            if relevant {
                 if let Some(mut hover) = hover {
                     if !hover.hovered {
                         hover.hovered = true;
                     }
                 }
+                #[cfg(feature = "family")]
                 if let Some(shared_interaction) = family_interaction {
-                    *interaction = *shared_interaction;
+                    *interaction = shared_interaction;
                 }
             } else if let Some(mut hover) = hover {
                 if hover.hovered {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,14 @@ impl Default for UpdatePicks {
     }
 }
 
+/// Enable/disable treating family trees as one pickable entity
+pub struct FamilyPickingState(pub(crate) bool);
+impl Default for FamilyPickingState {
+    fn default() -> Self {
+        FamilyPickingState(true)
+    }
+}
+
 pub struct DefaultPickingPlugins;
 
 impl PluginGroup for DefaultPickingPlugins {
@@ -170,6 +178,14 @@ impl PluginGroup for HighlightablePickingPlugins {
     fn build(&mut self, group: &mut PluginGroupBuilder) {
         group.add(CustomHighlightPlugin(StandardMaterialHighlight));
         group.add(CustomHighlightPlugin(ColorMaterialHighlight));
+    }
+}
+
+/// Enables treating family trees as one pickable entity
+pub struct FamilyPickingPlugin;
+impl Plugin for FamilyPickingPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<FamilyPickingState>();
     }
 }
 


### PR DESCRIPTION
# Overview
Implements _rough_ family selection

The goal of this feature is to be able to treat a family of entities as one "pickable object".

Uses for this would be spawning a scene of objects that are disjoint meshes but you intend to treat as one "thing".

Note two API choices being made:
1. All entities in a pickable faimliy must have the PickableMesh component.
2. There is no explicit PickableFmaily component, meaning a family of PickableMesh entities will be selected as one entity.

Currently the functionality is gated with a feature flag, but I'm considering moving to a Bundle/Plugin option.
Then you can choose on a per-entity basis if it's in a "Family Selection" group instead of it being global.

# Examples

```
cargo run --example family --features family
```

# Tasks

- [ ] Resolve conflicts with `main`. This branch was based on `v0.5.4`.
- [x] Add feature to enable/disable this functionality.
- [ ] Finalize API
- [ ] Finalize implementation
- ~GLTF scene example.~

After logging into GLTF loading I think that should be a different body of work.

Refs: #108 