### PR TITLE
FIx for issue #124 submitted by BessBrahmin.

### DIFF
--- a/src/focus.rs
+++ b/src/focus.rs
@@ -40,7 +40,9 @@ pub fn pause_for_picking_blockers(
         Query<&Interaction, Or<(With<Node>, With<PickingBlocker>)>>,
     )>,
 ) {
+    let mut no_ui_interactions = true;
     for ui_interaction in interactions.p1().iter() {
+        no_ui_interactions = false;
         if *ui_interaction != Interaction::None {
             for (mut interaction, hover, _, _) in &mut interactions.p0().iter_mut() {
                 if *interaction != Interaction::None {
@@ -57,6 +59,9 @@ pub fn pause_for_picking_blockers(
         } else {
             paused.0 = false;
         }
+    }
+    if no_ui_interactions {
+        paused.0 = false;
     }
 }
 

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -40,9 +40,8 @@ pub fn pause_for_picking_blockers(
         Query<&Interaction, Or<(With<Node>, With<PickingBlocker>)>>,
     )>,
 ) {
-    let mut no_ui_interactions = true;
+    paused.0 = false;
     for ui_interaction in interactions.p1().iter() {
-        no_ui_interactions = false;
         if *ui_interaction != Interaction::None {
             for (mut interaction, hover, _, _) in &mut interactions.p0().iter_mut() {
                 if *interaction != Interaction::None {
@@ -56,12 +55,7 @@ pub fn pause_for_picking_blockers(
             }
             paused.0 = true;
             return;
-        } else {
-            paused.0 = false;
         }
-    }
-    if no_ui_interactions {
-        paused.0 = false;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,10 +152,13 @@ impl Plugin for InteractablePickingPlugin {
                     .with_system(
                         mesh_selection
                             .label(PickingSystem::Selection)
-                            .before(PickingSystem::Events)
                             .after(PickingSystem::Focus),
                     )
-                    .with_system(mesh_events_system.label(PickingSystem::Events)),
+                    .with_system(
+                        mesh_events_system
+                            .label(PickingSystem::Events)
+                            .after(PickingSystem::Selection),
+                    ),
             );
     }
 }


### PR DESCRIPTION
After despawning all ui elements PauseForBlockers resource would become permanently set to true. This fixes issue by checking if there stting PauseForBlockers to false if there are no ui interactions.