### PR TITLE
add UpdatePickSourcePositions system label

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use highlight::{get_initial_mesh_highlight_asset, ColorMaterialHighlight, Highli
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
 pub enum PickingSystem {
+    UpdatePickSourcePositions,
     BuildRays,
     UpdateRaycast,
     UpdateIntersections,
@@ -106,7 +107,11 @@ impl Plugin for PickingPlugin {
                     .with_run_criteria(|state: Res<PickingPluginsState>| {
                         simple_criteria(state.enable_picking)
                     })
-                    .with_system(update_pick_source_positions.before(PickingSystem::BuildRays))
+                    .with_system(
+                        update_pick_source_positions
+                            .label(PickingSystem::UpdatePickSourcePositions)
+                            .before(PickingSystem::BuildRays),
+                    )
                     .with_system(
                         bevy_mod_raycast::build_rays::<PickingRaycastSet>
                             .label(PickingSystem::BuildRays)


### PR DESCRIPTION
https://github.com/aevyrie/bevy_mod_picking/blob/34f2f64d7e8f985d09fc71c7e4791579d72b5f23/src/lib.rs#L100-L126
As above, `update_pick_source_positions` is the first executed system and a system which enables or disables picking plugins is desired to run before this system. However this system does not have a public label. So I think it is necessary to apply a `UpdatePickSourcePosition` label to this system and export the label.