### PR TITLE
make CustomHighlightPlugin usable outside of plugin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ impl PluginGroup for HighlightablePickingPlugins {
 /// A highlighting plugin, generic over any asset that might be used for rendering the different
 /// highlighting states.
 #[derive(Default)]
-pub struct CustomHighlightPlugin<T: 'static + Highlightable + Sync + Send>(T);
+pub struct CustomHighlightPlugin<T: 'static + Highlightable + Sync + Send>(pub T);
 
 impl<T> Plugin for CustomHighlightPlugin<T>
 where


### PR DESCRIPTION
Tried to set custom materials in my project and failed because it has a private field. Suggesting this change or requesting wisdom to overcome this build error:
![Screenshot from 2022-06-08 15-21-05](https://user-images.githubusercontent.com/668981/172627354-3c4a6135-8484-4708-b387-ed23907e0c65.png)

