### PR TITLE
fix errors rustc was complaining about

### DIFF
--- a/examples/deselection.rs
+++ b/examples/deselection.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, window::PresentMode};
-use bevy_mod_picking::{DefaultPickingPlugins, NoDeselect, PickableBundle, PickingSourceBundle};
+use bevy_mod_picking::{DefaultPickingPlugins, NoDeselect, PickableBundle, PickingSource};
 
 /// This example is identical to the 3d_scene example, except a cube has been added, that when
 /// clicked on, won't deselect everything else you have selected.
@@ -61,9 +61,9 @@ fn setup(
     });
     // camera
     commands
-        .spawn_bundle(PerspectiveCameraBundle {
+        .spawn_bundle(Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         })
-        .insert_bundle(PickingSourceBundle::default());
+        .insert(PickingSource::default());
 }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_mod_picking::{DefaultPickingPlugins, PickableBundle, PickingEvent, PickingSourceBundle};
+use bevy_mod_picking::{DefaultPickingPlugins, PickableBundle, PickingEvent, PickingSource};
 
 fn main() {
     App::new()
@@ -50,9 +50,9 @@ fn setup(
         ..Default::default()
     });
     commands
-        .spawn_bundle(PerspectiveCameraBundle {
+        .spawn_bundle(Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         })
-        .insert_bundle(PickingSourceBundle::default()); // <- Sets the camera to use for picking.
+        .insert(PickingSource::default()); // <- Sets the camera to use for picking.
 }

--- a/examples/minimal_2d.rs
+++ b/examples/minimal_2d.rs
@@ -1,7 +1,5 @@
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
-use bevy_mod_picking::{
-    DebugEventsPlugin, DefaultPickingPlugins, PickableBundle, PickingSourceBundle,
-};
+use bevy_mod_picking::{DebugEventsPlugin, DefaultPickingPlugins, PickableBundle, PickingSource};
 
 fn main() {
     App::new()
@@ -28,6 +26,6 @@ fn setup(
         .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
                                                    // camera
     commands
-        .spawn_bundle(OrthographicCameraBundle::new_2d())
-        .insert_bundle(PickingSourceBundle::default()); // <- Sets the camera to use for picking.
+        .spawn_bundle(Camera2dBundle::default())
+        .insert(PickingSource::default()); // <- Sets the camera to use for picking.
 }

--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -1,92 +1,20 @@
 use bevy::{
-    core_pipeline::{self, AlphaMask3d, Opaque3d, Transparent3d},
     prelude::*,
-    render::{
-        camera::{ActiveCamera, CameraTypePlugin, RenderTarget},
-        render_graph::{self, NodeRunError, RenderGraph, RenderGraphContext, SlotValue},
-        render_phase::RenderPhase,
-        renderer::RenderContext,
-        RenderApp, RenderStage,
-    },
+    render::camera::RenderTarget,
     window::{CreateWindow, WindowId},
 };
-use bevy_mod_picking::{
-    DebugCursorPickingPlugin, DebugEventsPlugin, DefaultPickingPlugins, PickableBundle,
-};
+use bevy_mod_picking::{DebugEventsPlugin, DefaultPickingPlugins, PickableBundle};
 
 /// This example creates a second window and draws a mesh from two different cameras, one in each window
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(SecondWindowCameraPlugin)
         .add_plugins(DefaultPickingPlugins)
-        .add_plugin(DebugCursorPickingPlugin) // <- Adds the green debug cursor.
         .add_plugin(DebugEventsPlugin) // <- Adds debug event logging.
         .add_startup_system(setup)
         .add_startup_system(create_new_window)
         .run();
 }
-
-struct SecondWindowCameraPlugin;
-impl Plugin for SecondWindowCameraPlugin {
-    fn build(&self, app: &mut App) {
-        // adds the `ActiveCamera<SecondWindowCamera3d>` resource and extracts the camera into the render world
-        app.add_plugin(CameraTypePlugin::<SecondWindowCamera3d>::default());
-
-        let render_app = app.sub_app_mut(RenderApp);
-
-        // add `RenderPhase<Opaque3d>`, `RenderPhase<AlphaMask3d>` and `RenderPhase<Transparent3d>` camera phases
-        render_app.add_system_to_stage(RenderStage::Extract, extract_second_camera_phases);
-
-        // add a render graph node that executes the 3d subgraph
-        let mut render_graph = render_app.world.resource_mut::<RenderGraph>();
-        let second_window_node = render_graph.add_node("second_window_cam", SecondWindowDriverNode);
-        render_graph
-            .add_node_edge(
-                core_pipeline::node::MAIN_PASS_DEPENDENCIES,
-                second_window_node,
-            )
-            .unwrap();
-        render_graph
-            .add_node_edge(core_pipeline::node::CLEAR_PASS_DRIVER, second_window_node)
-            .unwrap();
-    }
-}
-
-struct SecondWindowDriverNode;
-impl render_graph::Node for SecondWindowDriverNode {
-    fn run(
-        &self,
-        graph: &mut RenderGraphContext,
-        _: &mut RenderContext,
-        world: &World,
-    ) -> Result<(), NodeRunError> {
-        if let Some(camera) = world.resource::<ActiveCamera<SecondWindowCamera3d>>().get() {
-            graph.run_sub_graph(
-                core_pipeline::draw_3d_graph::NAME,
-                vec![SlotValue::Entity(camera)],
-            )?;
-        }
-
-        Ok(())
-    }
-}
-
-fn extract_second_camera_phases(
-    mut commands: Commands,
-    active: Res<ActiveCamera<SecondWindowCamera3d>>,
-) {
-    if let Some(entity) = active.get() {
-        commands.get_or_spawn(entity).insert_bundle((
-            RenderPhase::<Opaque3d>::default(),
-            RenderPhase::<AlphaMask3d>::default(),
-            RenderPhase::<Transparent3d>::default(),
-        ));
-    }
-}
-
-#[derive(Component, Default)]
-struct SecondWindowCamera3d;
 
 fn create_new_window(mut create_window_events: EventWriter<CreateWindow>, mut commands: Commands) {
     let window_id = WindowId::new();
@@ -104,16 +32,15 @@ fn create_new_window(mut create_window_events: EventWriter<CreateWindow>, mut co
 
     // second window camera
     commands
-        .spawn_bundle(PerspectiveCameraBundle {
+        .spawn_bundle(Camera3dBundle {
             camera: Camera {
                 target: RenderTarget::Window(window_id),
                 ..default()
             },
             transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-            marker: SecondWindowCamera3d,
-            ..PerspectiveCameraBundle::new()
+            ..default()
         })
-        .insert_bundle(bevy_mod_picking::PickingSourceBundle::default());
+        .insert(bevy_mod_picking::PickingSource::default());
 }
 
 fn setup(
@@ -136,9 +63,9 @@ fn setup(
     });
     // main camera
     commands
-        .spawn_bundle(PerspectiveCameraBundle {
+        .spawn_bundle(Camera3dBundle {
             transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         })
-        .insert_bundle(bevy_mod_picking::PickingSourceBundle::default());
+        .insert(bevy_mod_picking::PickingSource::default());
 }

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -48,12 +48,12 @@ fn setup(
 
     // Camera
     commands
-        .spawn_bundle(PerspectiveCameraBundle {
+        .spawn_bundle(Camera3dBundle {
             transform: Transform::from_xyz(half_width as f32, half_width as f32, half_width as f32)
                 .looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         })
-        .insert_bundle(PickingSourceBundle::default());
+        .insert(PickingSource::default());
 
     // Spawn a cube of spheres.
     for x in -half_width..half_width {


### PR DESCRIPTION
Co-authored-by: Brian Merchant <bzm3r@users.noreply.github.com>

Hey Aevyrie, Brian and I were starting to look at porting our code to your refactor branch by running the examples. In order to run the examples we needed to fix the errors rustc was complaining about. The examples now run, but the only example that seems to work properly is the only one we didn't touch (examples/minimal.rs) so we may have 'fixed' things wrong. Is the examples not working a result of stuff needing to be added? Is there anything we can do to help?