### PR TITLE
Make highlights optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_picking"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Aevyrie <aevyrie@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -11,13 +11,11 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
-    "render",
-] }
-bevy_mod_raycast = { git = "https://github.com/aevyrie/bevy_mod_raycast", branch = "main" }
+bevy = { version = "0.7", default-features = false, features = ["render"] }
+bevy_mod_raycast = "0.4.0"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+bevy = { version = "0.7", default-features = false, features = [
     "bevy_winit",
     "x11",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [dependencies]
 bevy = { version = "0.7", default-features = false, features = ["render"] }
-bevy_mod_raycast = "0.4.0"
+bevy_mod_raycast = "0.5.0"
 
 [dev-dependencies]
 bevy = { version = "0.7", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_picking"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Aevyrie <aevyrie@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# 3D Mouse Picking for Bevy
+<div align="center">
+
+# Mouse Picking for Bevy
 
 [![crates.io](https://img.shields.io/crates/v/bevy_mod_picking)](https://crates.io/crates/bevy_mod_picking)
 [![docs.rs](https://docs.rs/bevy_mod_picking/badge.svg)](https://docs.rs/bevy_mod_picking)
 [![CI](https://github.com/aevyrie/bevy_mod_picking/workflows/CI/badge.svg?branch=master)](https://github.com/aevyrie/bevy_mod_picking/actions?query=workflow%3A%22CI%22+branch%3Amaster)
 [![Bevy tracking](https://img.shields.io/badge/Bevy%20tracking-main-lightblue)](https://github.com/bevyengine/bevy/blob/main/docs/plugins_guidelines.md#main-branch-tracking)
 
-A [Bevy](https://github.com/bevyengine/bevy) plugin for 3D mouse picking, making it easy to interact
-with geometry in Bevy using a mouse or touch. This plugin is built with [`bevy_mod_raycast`](https://github.com/aevyrie/bevy_mod_raycast).
+</div>
+
+A [Bevy](https://github.com/bevyengine/bevy) plugin for mouse picking, making it easy to interact with geometry in Bevy using a mouse or touch. This plugin is built with [`bevy_mod_raycast`](https://github.com/aevyrie/bevy_mod_raycast).
 
 <br/><p align="center">
 <img src="https://user-images.githubusercontent.com/2632925/114128723-d8de1b00-98b1-11eb-9b25-812fcf6664e2.gif">
@@ -65,13 +68,13 @@ cargo run --example minimal
 
 I intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
-|bevy|bevy_mod_picking|
-|---|---|
-|0.7|0.6|
-|0.6|0.5|
-|0.5|0.4|
-|0.4|0.3|
-|0.3|0.2|
+| bevy | bevy_mod_picking |
+| ---- | ---------------- |
+| 0.7  | 0.6, 0.7         |
+| 0.6  | 0.5              |
+| 0.5  | 0.4              |
+| 0.4  | 0.3              |
+| 0.3  | 0.2              |
 
 # License
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -14,6 +14,7 @@ pub struct Highlighting<T: Asset> {
     pub hovered: Option<Handle<T>>,
     pub pressed: Option<Handle<T>>,
     pub selected: Option<Handle<T>>,
+    pub hover_selected: Option<Handle<T>>,
 }
 
 /// Resource that defines the default highlighting assets to use. This can be overridden per-entity
@@ -22,6 +23,7 @@ pub struct DefaultHighlighting<T: Highlightable + ?Sized> {
     pub hovered: Option<Handle<T::HighlightAsset>>,
     pub pressed: Option<Handle<T::HighlightAsset>>,
     pub selected: Option<Handle<T::HighlightAsset>>,
+    pub hover_selected: Option<Handle<T::HighlightAsset>>,
 }
 
 /// This trait makes it possible for highlighting to be generic over any type of asset.
@@ -50,6 +52,7 @@ impl Highlightable for StandardMaterialHighlight {
             hovered: Some(materials.add(Color::rgb(0.35, 0.35, 0.35).into())),
             pressed: Some(materials.add(Color::rgb(0.35, 0.75, 0.35).into())),
             selected: Some(materials.add(Color::rgb(0.35, 0.35, 0.75).into())),
+            hover_selected: Some(materials.add(Color::rgb(0.35, 0.75, 0.75).into())),
         }
     }
 }
@@ -66,6 +69,7 @@ impl Highlightable for ColorMaterialHighlight {
             hovered: Some(materials.add(Color::rgb(0.35, 0.35, 0.35).into())),
             pressed: Some(materials.add(Color::rgb(0.35, 0.75, 0.35).into())),
             selected: Some(materials.add(Color::rgb(0.35, 0.35, 0.75).into())),
+            hover_selected: Some(materials.add(Color::rgb(0.35, 0.75, 0.75).into())),
         }
     }
 }
@@ -91,6 +95,7 @@ pub fn get_initial_mesh_highlight_asset<T: Asset>(
                     hovered: None,
                     pressed: None,
                     selected: None,
+                    hover_selected: None,
                 };
                 commands.entity(entity).insert(init_component);
             }
@@ -140,16 +145,32 @@ pub fn mesh_highlighting<T: 'static + Highlightable + Send + Sync>(
                 )
             }
             Interaction::Hovered => {
-                highlight.hovered.as_ref().unwrap_or(
-                    global_default_highlight.hovered.as_ref().unwrap_or(
-                        &highlight.initial
+                if selection.filter(|s| s.selected()).is_some() {
+                    highlight.hover_selected.as_ref().unwrap_or(
+                        global_default_highlight.hover_selected.as_ref().unwrap_or(
+                            highlight.hovered.as_ref().unwrap_or(
+                                highlight.selected.as_ref().unwrap_or(
+                                    global_default_highlight.hovered.as_ref().unwrap_or(
+                                        global_default_highlight.selected.as_ref().unwrap_or(
+                                            &highlight.initial
+                                        )
+                                    )
+                                )
+                            )
+                        )
                     )
-                )
+                } else {
+                    highlight.hovered.as_ref().unwrap_or(
+                        global_default_highlight.hovered.as_ref().unwrap_or(
+                            &highlight.initial
+                        )
+                    )
+                }
             }
             Interaction::None => {
                 if selection.filter(|s| s.selected()).is_some() {
                     highlight.selected.as_ref().unwrap_or(
-                        global_default_highlight.as_ref().unwrap_or(
+                        global_default_highlight.selected.as_ref().unwrap_or(
                             &highlight.initial
                         )
                     )


### PR DESCRIPTION
Thanks for making this picking library; it's super easy to use and valuable!

I found that in my use case the hover highlight was very distracting. Colors would flash wildly just from moving the cursor across the window.

This PR reworks highlighting behavior so that all the global highlights are optional. When a global highlight is `None` and the entity highlight component is also `None`, then there will simply be no highlight applied (..except in the case of Hover+Selected explained below..).

This also adds a `hover_selected` field which will be used when an object is both selected and being hovered over at the same time. If `hover_selected` is `None` for both the entity highlighting and the global highlighting, then the coloring falls back to hover and selected behavior with this prioritization:
```
entity hover_selected > global hover_selected > entity hovered > entity selected > global hovered > global selected > no highlight
```

I based this PR off of the `v0.7.0` tag because `main` wasn't able to compile for me and I couldn't be bothered to figure out why :grimacing: ...But if you'd like me to revert the `Cargo.toml` and/or the `README.md` just let me know.

Unfortunately this is a bit of an API break so I can understand if that may be controversial. Luckily all of the examples continue to work as-is. The change will only impact users who are customizing their default coloring, and they only need to deal with the switch from `T` to `Option<T>` which shouldn't be a very big deal.