### PR TITLE
make modules public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
-mod events;
-mod focus;
-mod highlight;
-mod mouse;
-mod selection;
+pub mod events;
+pub mod focus;
+pub mod highlight;
+pub mod mouse;
+pub mod selection;
 
 pub use crate::{
     events::{event_debug_system, mesh_events_system, HoverEvent, PickingEvent, SelectionEvent},


### PR DESCRIPTION
Fixes breaking change where user systems cannot insert systems before highlighting, by making the systems public.