### PR TITLE
Don't skip existing pick_sources if one returns None

### DIFF
--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -23,7 +23,7 @@ pub fn update_pick_source_positions(
             &touches_input,
         ) {
             Some(value) => value,
-            None => return,
+            None => continue,
         };
         match *update_picks {
             UpdatePicks::EveryFrame(cached_cursor_pos) => {


### PR DESCRIPTION
Helps with setup where single 3d camera has usual PickingCameraBundle and also a child with another RayCastSource for picking center of screen. Child has no camera so get_inputs returns None and other entities with PickingCamera are never processed without this change