### PR TITLE
Update to Bevy 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,12 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
-    "render",
-] }
+bevy = { version = "0.9", default-features = false, features = ["render"] }
 
-bevy_mod_raycast = { git = "https://github.com/olegomon/bevy_mod_raycast", branch = "main", default-features = false }
+bevy_mod_raycast = "0.7"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+bevy = { version = "0.9", default-features = false, features = [
     "bevy_pbr",
     "bevy_winit",
     "bevy_ui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-fe
     "render",
 ] }
 
-bevy_mod_raycast = { git = "https://github.com/aevyrie/bevy_mod_raycast", branch = "main", default-features = false }
+bevy_mod_raycast = { git = "https://github.com/olegomon/bevy_mod_raycast", branch = "main", default-features = false }
 
 [dev-dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [

--- a/examples/deselection.rs
+++ b/examples/deselection.rs
@@ -1,16 +1,19 @@
 use bevy::{prelude::*, window::PresentMode};
-use bevy_mod_picking::{DefaultPickingPlugins, NoDeselect, PickableBundle, PickingCameraBundle};
+use bevy_mod_picking::{HighlightablePickingPlugins, DefaultPickingPlugins, NoDeselect, PickableBundle, PickingCameraBundle};
 
 /// This example is identical to the 3d_scene example, except a cube has been added, that when
 /// clicked on, won't deselect everything else you have selected.
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
-            present_mode: PresentMode::AutoNoVsync, // Reduce input latency
-            ..Default::default()
-        })
-        .add_plugins(DefaultPlugins)
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction, and Highlighting plugins.
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: WindowDescriptor {
+                present_mode: PresentMode::AutoNoVsync, // Reduce input latency
+                ..default()
+            },
+            ..default()
+        }))
+        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
+        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
         .add_startup_system(setup)
         .run();
 }
@@ -23,34 +26,34 @@ fn setup(
 ) {
     // plane
     commands
-        .spawn_bundle(PbrBundle {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
         })
-        .insert_bundle(PickableBundle::default());
+        .insert(PickableBundle::default());
 
     // cube
     commands
-        .spawn_bundle(PbrBundle {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            material: materials.add(Color::rgb(0.0, 0.7, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
-        .insert_bundle(PickableBundle::default());
+        .insert(PickableBundle::default());
     // cube with NoDeselect
     commands
-        .spawn_bundle(PbrBundle {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            material: materials.add(Color::rgb(1.8, 0.7, 0.6).into()),
             transform: Transform::from_xyz(1.5, 0.5, 0.0),
             ..Default::default()
         })
-        .insert_bundle(PickableBundle::default())
+        .insert(PickableBundle::default())
         .insert(NoDeselect);
     // light
-    commands.spawn_bundle(PointLightBundle {
+    commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
         point_light: PointLight {
             intensity: 1500.0,
@@ -61,9 +64,9 @@ fn setup(
     });
     // camera
     commands
-        .spawn_bundle(Camera3dBundle {
+        .spawn(Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         })
-        .insert_bundle(PickingCameraBundle::default());
+        .insert(PickingCameraBundle::default());
 }

--- a/examples/deselection.rs
+++ b/examples/deselection.rs
@@ -1,8 +1,5 @@
 use bevy::{prelude::*, window::PresentMode};
-use bevy_mod_picking::{
-    DefaultPickingPlugins, HighlightablePickingPlugins, NoDeselect, PickableBundle,
-    PickingCameraBundle,
-};
+use bevy_mod_picking::{DefaultPickingPlugins, NoDeselect, PickableBundle, PickingCameraBundle};
 
 /// This example is identical to the 3d_scene example, except a cube has been added, that when
 /// clicked on, won't deselect everything else you have selected.
@@ -15,8 +12,7 @@ fn main() {
             },
             ..default()
         }))
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
-        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
+        .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
         .add_startup_system(setup)
         .run();
 }

--- a/examples/deselection.rs
+++ b/examples/deselection.rs
@@ -1,5 +1,8 @@
 use bevy::{prelude::*, window::PresentMode};
-use bevy_mod_picking::{HighlightablePickingPlugins, DefaultPickingPlugins, NoDeselect, PickableBundle, PickingCameraBundle};
+use bevy_mod_picking::{
+    DefaultPickingPlugins, HighlightablePickingPlugins, NoDeselect, PickableBundle,
+    PickingCameraBundle,
+};
 
 /// This example is identical to the 3d_scene example, except a cube has been added, that when
 /// clicked on, won't deselect everything else you have selected.
@@ -25,33 +28,36 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // plane
-    commands
-        .spawn(PbrBundle {
+    commands.spawn((
+        PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
-        })
-        .insert(PickableBundle::default());
+        },
+        PickableBundle::default(),
+    ));
 
     // cube
-    commands
-        .spawn(PbrBundle {
+    commands.spawn((
+        PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.0, 0.7, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
-        })
-        .insert(PickableBundle::default());
+        },
+        PickableBundle::default(),
+    ));
     // cube with NoDeselect
-    commands
-        .spawn(PbrBundle {
+    commands.spawn((
+        PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(1.8, 0.7, 0.6).into()),
             transform: Transform::from_xyz(1.5, 0.5, 0.0),
             ..Default::default()
-        })
-        .insert(PickableBundle::default())
-        .insert(NoDeselect);
+        },
+        PickableBundle::default(),
+        NoDeselect,
+    ));
     // light
     commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
@@ -63,10 +69,11 @@ fn setup(
         ..Default::default()
     });
     // camera
-    commands
-        .spawn(Camera3dBundle {
+    commands.spawn((
+        Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
-        })
-        .insert(PickingCameraBundle::default());
+        },
+        PickingCameraBundle::default(),
+    ));
 }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,10 +1,12 @@
 use bevy::prelude::*;
-use bevy_mod_picking::{DefaultPickingPlugins, PickableBundle, PickingCameraBundle, PickingEvent};
+
+use bevy_mod_picking::{HighlightablePickingPlugins, DefaultPickingPlugins, PickableBundle, PickingCameraBundle, PickingEvent};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction, and Highlighting plugins.
+        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
+        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
         .add_startup_system(setup)
         .add_system_to_stage(CoreStage::PostUpdate, print_events)
         .run();
@@ -26,21 +28,21 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     commands
-        .spawn_bundle(PbrBundle {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
         })
-        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
     commands
-        .spawn_bundle(PbrBundle {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
-        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
-    commands.spawn_bundle(PointLightBundle {
+        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
+    commands.spawn(PointLightBundle {
         point_light: PointLight {
             intensity: 1500.0,
             shadows_enabled: true,
@@ -50,9 +52,9 @@ fn setup(
         ..Default::default()
     });
     commands
-        .spawn_bundle(Camera3dBundle {
+        .spawn(Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         })
-        .insert_bundle(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
+        .insert(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
 }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,15 +1,11 @@
 use bevy::prelude::*;
 
-use bevy_mod_picking::{
-    DefaultPickingPlugins, HighlightablePickingPlugins, PickableBundle, PickingCameraBundle,
-    PickingEvent,
-};
+use bevy_mod_picking::{DefaultPickingPlugins, PickableBundle, PickingCameraBundle, PickingEvent};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
-        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
+        .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
         .add_startup_system(setup)
         .add_system_to_stage(CoreStage::PostUpdate, print_events)
         .run();

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,6 +1,9 @@
 use bevy::prelude::*;
 
-use bevy_mod_picking::{HighlightablePickingPlugins, DefaultPickingPlugins, PickableBundle, PickingCameraBundle, PickingEvent};
+use bevy_mod_picking::{
+    DefaultPickingPlugins, HighlightablePickingPlugins, PickableBundle, PickingCameraBundle,
+    PickingEvent,
+};
 
 fn main() {
     App::new()
@@ -27,21 +30,23 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        .spawn(PbrBundle {
+    commands.spawn((
+        PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
-        })
-        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
-    commands
-        .spawn(PbrBundle {
+        },
+        PickableBundle::default(), // <- Makes the mesh pickable.
+    ));
+    commands.spawn((
+        PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
-        })
-        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
+        },
+        PickableBundle::default(), // <- Makes the mesh pickable.
+    ));
     commands.spawn(PointLightBundle {
         point_light: PointLight {
             intensity: 1500.0,
@@ -51,10 +56,11 @@ fn setup(
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..Default::default()
     });
-    commands
-        .spawn(Camera3dBundle {
+    commands.spawn((
+        Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
-        })
-        .insert(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
+        },
+        PickingCameraBundle::default(), // <- Sets the camera to use for picking.
+    ));
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,17 +1,18 @@
 use bevy::{prelude::*, window::PresentMode};
-use bevy_mod_picking::{
-    DebugCursorPickingPlugin, DebugEventsPickingPlugin, DefaultPickingPlugins, PickableBundle,
-    PickingCameraBundle,
-};
+
+use bevy_mod_picking::{DebugCursorPickingPlugin, DebugEventsPickingPlugin, HighlightablePickingPlugins, DefaultPickingPlugins, PickableBundle, PickingCameraBundle};
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
-            present_mode: PresentMode::AutoNoVsync, // Reduce input latency
-            ..Default::default()
-        })
-        .add_plugins(DefaultPlugins)
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction, and Highlighting plugins.
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: WindowDescriptor {
+                present_mode: PresentMode::AutoNoVsync, // Reduce input latency
+                ..default()
+            },
+            ..default()
+        }))
+        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
+        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
         .add_plugin(DebugCursorPickingPlugin) // <- Adds the green debug cursor.
         .add_plugin(DebugEventsPickingPlugin) // <- Adds debug event logging.
         .add_startup_system(setup)
@@ -26,23 +27,23 @@ fn setup(
 ) {
     // plane
     commands
-        .spawn_bundle(PbrBundle {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
         })
-        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
                                                    // cube
     commands
-        .spawn_bundle(PbrBundle {
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
-        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
                                                    // light
-    commands.spawn_bundle(PointLightBundle {
+    commands.spawn(PointLightBundle {
         point_light: PointLight {
             intensity: 1500.0,
             shadows_enabled: true,
@@ -53,9 +54,9 @@ fn setup(
     });
     // camera
     commands
-        .spawn_bundle(Camera3dBundle {
+        .spawn(Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         })
-        .insert_bundle(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
+        .insert(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,6 +1,9 @@
 use bevy::{prelude::*, window::PresentMode};
 
-use bevy_mod_picking::{DebugCursorPickingPlugin, DebugEventsPickingPlugin, HighlightablePickingPlugins, DefaultPickingPlugins, PickableBundle, PickingCameraBundle};
+use bevy_mod_picking::{
+    DebugCursorPickingPlugin, DebugEventsPickingPlugin, DefaultPickingPlugins,
+    HighlightablePickingPlugins, PickableBundle, PickingCameraBundle,
+};
 
 fn main() {
     App::new()
@@ -13,7 +16,7 @@ fn main() {
         }))
         .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
         .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
-        .add_plugin(DebugCursorPickingPlugin) // <- Adds the green debug cursor.
+        .add_plugin(DebugCursorPickingPlugin) // <- Adds the debug cursor.
         .add_plugin(DebugEventsPickingPlugin) // <- Adds debug event logging.
         .add_startup_system(setup)
         .run();
@@ -25,24 +28,23 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // plane
-    commands
-        .spawn(PbrBundle {
+    commands.spawn((
+        PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
-        })
-        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
-                                                   // cube
-    commands
-        .spawn(PbrBundle {
+        },
+        PickableBundle::default(), // <- Makes the mesh pickable.
+    ));
+    commands.spawn((
+        PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
-        })
-        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
-                                                   // light
+        },
+        PickableBundle::default(), // <- Makes the mesh pickable.
+    ));
     commands.spawn(PointLightBundle {
         point_light: PointLight {
             intensity: 1500.0,
@@ -52,11 +54,11 @@ fn setup(
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..Default::default()
     });
-    // camera
-    commands
-        .spawn(Camera3dBundle {
+    commands.spawn((
+        Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
-        })
-        .insert(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
+        },
+        PickingCameraBundle::default(), // <- Sets the camera to use for picking.
+    ));
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,8 +1,8 @@
 use bevy::{prelude::*, window::PresentMode};
 
 use bevy_mod_picking::{
-    DebugCursorPickingPlugin, DebugEventsPickingPlugin, DefaultPickingPlugins,
-    HighlightablePickingPlugins, PickableBundle, PickingCameraBundle,
+    DebugCursorPickingPlugin, DebugEventsPickingPlugin, DefaultPickingPlugins, PickableBundle,
+    PickingCameraBundle,
 };
 
 fn main() {
@@ -14,10 +14,9 @@ fn main() {
             },
             ..default()
         }))
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
-        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
-        .add_plugin(DebugCursorPickingPlugin) // <- Adds the debug cursor.
-        .add_plugin(DebugEventsPickingPlugin) // <- Adds debug event logging.
+        .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
+        .add_plugin(DebugCursorPickingPlugin) // <- Adds the debug cursor (optional)
+        .add_plugin(DebugEventsPickingPlugin) // <- Adds debug event logging (optional)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/minimal_2d.rs
+++ b/examples/minimal_2d.rs
@@ -1,5 +1,8 @@
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
-use bevy_mod_picking::{DebugEventsPickingPlugin, HighlightablePickingPlugins, DefaultPickingPlugins, PickableBundle, PickingCameraBundle};
+use bevy_mod_picking::{
+    DebugEventsPickingPlugin, DefaultPickingPlugins, HighlightablePickingPlugins, PickableBundle,
+    PickingCameraBundle,
+};
 
 fn main() {
     App::new()
@@ -17,16 +20,17 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    commands
-        .spawn(MaterialMesh2dBundle {
+    commands.spawn((
+        MaterialMesh2dBundle {
             mesh: meshes.add(Mesh::from(shape::Quad::default())).into(),
             transform: Transform::default().with_scale(Vec3::splat(128.)),
             material: materials.add(ColorMaterial::from(Color::PURPLE)),
             ..default()
-        })
-        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
-                                                   // camera
-    commands
-        .spawn(Camera2dBundle::default())
-        .insert(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
+        },
+        PickableBundle::default(), // <- Makes the mesh pickable.
+    ));
+    // camera
+    commands.spawn(
+        (Camera2dBundle::default(), PickingCameraBundle::default()), // <- Sets the camera to use for picking.
+    );
 }

--- a/examples/minimal_2d.rs
+++ b/examples/minimal_2d.rs
@@ -1,12 +1,11 @@
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
-use bevy_mod_picking::{
-    DebugEventsPickingPlugin, DefaultPickingPlugins, PickableBundle, PickingCameraBundle,
-};
+use bevy_mod_picking::{DebugEventsPickingPlugin, HighlightablePickingPlugins, DefaultPickingPlugins, PickableBundle, PickingCameraBundle};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction, and Highlighting plugins.
+        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
+        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
         .add_plugin(DebugEventsPickingPlugin) // <- Adds debug event logging.
         .add_startup_system(setup)
         .run();
@@ -19,15 +18,15 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     commands
-        .spawn_bundle(MaterialMesh2dBundle {
+        .spawn(MaterialMesh2dBundle {
             mesh: meshes.add(Mesh::from(shape::Quad::default())).into(),
             transform: Transform::default().with_scale(Vec3::splat(128.)),
             material: materials.add(ColorMaterial::from(Color::PURPLE)),
             ..default()
         })
-        .insert_bundle(PickableBundle::default()); // <- Makes the mesh pickable.
+        .insert(PickableBundle::default()); // <- Makes the mesh pickable.
                                                    // camera
     commands
-        .spawn_bundle(Camera2dBundle::default())
-        .insert_bundle(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
+        .spawn(Camera2dBundle::default())
+        .insert(PickingCameraBundle::default()); // <- Sets the camera to use for picking.
 }

--- a/examples/minimal_2d.rs
+++ b/examples/minimal_2d.rs
@@ -1,14 +1,12 @@
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
 use bevy_mod_picking::{
-    DebugEventsPickingPlugin, DefaultPickingPlugins, HighlightablePickingPlugins, PickableBundle,
-    PickingCameraBundle,
+    DebugEventsPickingPlugin, DefaultPickingPlugins, PickableBundle, PickingCameraBundle,
 };
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
-        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
+        .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
         .add_plugin(DebugEventsPickingPlugin) // <- Adds debug event logging.
         .add_startup_system(setup)
         .run();

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -17,8 +17,7 @@ fn main() {
             },
             ..default()
         }))
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
-        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
+        .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -7,15 +7,18 @@ use bevy_mod_picking::*;
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
-            title: "bevy_mod_picking stress test".to_string(),
-            width: 800.,
-            height: 600.,
-            present_mode: PresentMode::AutoNoVsync, // Reduce input latency
-            ..Default::default()
-        })
-        .add_plugins(DefaultPlugins)
-        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction, and Highlighting plugins.
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: WindowDescriptor {
+                title: "bevy_mod_picking stress test".to_string(),
+                width: 800.,
+                height: 600.,
+                present_mode: PresentMode::AutoNoVsync, // Reduce input latency
+                ..default()
+            },
+            ..default()
+        }))
+        .add_plugins(DefaultPickingPlugins) // <- Adds Picking, Interaction plugins.
+        .add_plugins(HighlightablePickingPlugins) // <- Adds Highlighting plugins.
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
@@ -48,19 +51,19 @@ fn setup(
 
     // Camera
     commands
-        .spawn_bundle(Camera3dBundle {
+        .spawn(Camera3dBundle {
             transform: Transform::from_xyz(half_width as f32, half_width as f32, half_width as f32)
                 .looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         })
-        .insert_bundle(PickingCameraBundle::default());
+        .insert(PickingCameraBundle::default());
 
     // Spawn a cube of spheres.
     for x in -half_width..half_width {
         for y in -half_width..half_width {
             for z in -half_width..half_width {
                 commands
-                    .spawn_bundle(PbrBundle {
+                    .spawn(PbrBundle {
                         mesh: mesh_handle.clone(),
                         material: matl_handle.clone(),
                         transform: Transform::from_translation(Vec3::new(
@@ -70,13 +73,13 @@ fn setup(
                         )),
                         ..Default::default()
                     })
-                    .insert_bundle(PickableBundle::default());
+                    .insert(PickableBundle::default());
             }
         }
     }
 
     // Light
-    commands.spawn_bundle(PointLightBundle {
+    commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(half_width as f32, half_width as f32, half_width as f32),
         point_light: PointLight {
             intensity: 2500.0,

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -50,20 +50,21 @@ fn setup(
     });
 
     // Camera
-    commands
-        .spawn(Camera3dBundle {
+    commands.spawn((
+        Camera3dBundle {
             transform: Transform::from_xyz(half_width as f32, half_width as f32, half_width as f32)
                 .looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
-        })
-        .insert(PickingCameraBundle::default());
+        },
+        PickingCameraBundle::default(),
+    ));
 
     // Spawn a cube of spheres.
     for x in -half_width..half_width {
         for y in -half_width..half_width {
             for z in -half_width..half_width {
-                commands
-                    .spawn(PbrBundle {
+                commands.spawn((
+                    PbrBundle {
                         mesh: mesh_handle.clone(),
                         material: matl_handle.clone(),
                         transform: Transform::from_translation(Vec3::new(
@@ -72,8 +73,9 @@ fn setup(
                             z as f32,
                         )),
                         ..Default::default()
-                    })
-                    .insert(PickableBundle::default());
+                    },
+                    PickableBundle::default(),
+                ));
             }
         }
     }

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -96,28 +96,25 @@ pub fn mesh_focus(
     let mouse_clicked = mouse_button_input.just_pressed(MouseButton::Left)
         || touches_input.iter_just_pressed().next().is_some();
     for pick_source in pick_source_query.iter() {
-        // There is at least one entity under the cursor
-        if let Some(picks) = pick_source.intersect_list() {
-            for (topmost_entity, _intersection) in picks.iter() {
-                if let Ok((mut interaction, _hover, focus_policy, _entity)) =
-                    interactions.get_mut(*topmost_entity)
-                {
-                    if mouse_clicked {
-                        if *interaction != Interaction::Clicked {
-                            *interaction = Interaction::Clicked;
-                        }
-                    } else if *interaction == Interaction::None {
-                        *interaction = Interaction::Hovered;
+        for (topmost_entity, _intersection) in pick_source.intersections().iter() {
+            if let Ok((mut interaction, _hover, focus_policy, _entity)) =
+                interactions.get_mut(*topmost_entity)
+            {
+                if mouse_clicked {
+                    if *interaction != Interaction::Clicked {
+                        *interaction = Interaction::Clicked;
                     }
+                } else if *interaction == Interaction::None {
+                    *interaction = Interaction::Hovered;
+                }
 
-                    hovered_entity = Some(*topmost_entity);
+                hovered_entity = Some(*topmost_entity);
 
-                    match focus_policy.cloned().unwrap_or(FocusPolicy::Block) {
-                        FocusPolicy::Block => {
-                            break;
-                        }
-                        FocusPolicy::Pass => { /* allow the next node to be hovered/clicked */ }
+                match focus_policy.cloned().unwrap_or(FocusPolicy::Block) {
+                    FocusPolicy::Block => {
+                        break;
                     }
+                    FocusPolicy::Pass => { /* allow the next node to be hovered/clicked */ }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::{
     mouse::update_pick_source_positions,
     selection::{mesh_selection, NoDeselect, Selection},
 };
-pub use bevy_mod_raycast::{Primitive3d, RayCastSource, RayCastMesh};
+pub use bevy_mod_raycast::{Primitive3d, RaycastMesh, RaycastSource};
 
 use bevy::{app::PluginGroupBuilder, ecs::schedule::ShouldRun, prelude::*, ui::FocusPolicy};
 use highlight::{get_initial_mesh_highlight_asset, ColorMaterialHighlight, Highlight};
@@ -32,16 +32,16 @@ pub enum PickingSystem {
     Events,
 }
 
-/// A type alias for the concrete [RayCastMesh](bevy_mod_raycast::RayCastMesh) type used for Picking.
-pub type PickableMesh = RayCastMesh<PickingRaycastSet>;
-/// A type alias for the concrete [RayCastSource](bevy_mod_raycast::RayCastSource) type used for Picking.
-pub type PickingCamera = RayCastSource<PickingRaycastSet>;
+/// A type alias for the concrete [RaycastMesh](bevy_mod_raycast::RaycastMesh) type used for Picking.
+pub type PickableMesh = RaycastMesh<PickingRaycastSet>;
+/// A type alias for the concrete [RaycastSource](bevy_mod_raycast::RaycastSource) type used for Picking.
+pub type PickingCamera = RaycastSource<PickingRaycastSet>;
 
-/// This unit struct is used to tag the generic ray casting types `RayCastMesh` and
-/// `RayCastSource`. This means that all Picking ray casts are of the same type. Consequently, any
+/// This unit struct is used to tag the generic ray casting types `RaycastMesh` and
+/// `RaycastSource`. This means that all Picking ray casts are of the same type. Consequently, any
 /// meshes or ray sources that are being used by the picking plugin can be used by other ray
-/// casting systems because they will have distinct types, e.g.: `RayCastMesh<PickingRaycastSet>`
-/// vs. `RayCastMesh<MySuperCoolRaycastingType>`, and as such wil not result in collisions.
+/// casting systems because they will have distinct types, e.g.: `RaycastMesh<PickingRaycastSet>`
+/// vs. `RaycastMesh<MySuperCoolRaycastingType>`, and as such wil not result in collisions.
 pub struct PickingRaycastSet;
 
 #[derive(Clone, Debug, Resource)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::{
     mouse::update_pick_source_positions,
     selection::{mesh_selection, NoDeselect, Selection},
 };
-pub use bevy_mod_raycast::{Primitive3d, RayCastSource};
+pub use bevy_mod_raycast::{Primitive3d, RayCastSource, RayCastMesh};
 
 use bevy::{app::PluginGroupBuilder, ecs::schedule::ShouldRun, prelude::*, ui::FocusPolicy};
 use highlight::{get_initial_mesh_highlight_asset, ColorMaterialHighlight, Highlight};
@@ -33,9 +33,9 @@ pub enum PickingSystem {
 }
 
 /// A type alias for the concrete [RayCastMesh](bevy_mod_raycast::RayCastMesh) type used for Picking.
-pub type PickableMesh = bevy_mod_raycast::RayCastMesh<PickingRaycastSet>;
+pub type PickableMesh = RayCastMesh<PickingRaycastSet>;
 /// A type alias for the concrete [RayCastSource](bevy_mod_raycast::RayCastSource) type used for Picking.
-pub type PickingCamera = bevy_mod_raycast::RayCastSource<PickingRaycastSet>;
+pub type PickingCamera = RayCastSource<PickingRaycastSet>;
 
 /// This unit struct is used to tag the generic ray casting types `RayCastMesh` and
 /// `RayCastSource`. This means that all Picking ray casts are of the same type. Consequently, any
@@ -91,10 +91,10 @@ impl Default for UpdatePicks {
 pub struct DefaultPickingPlugins;
 
 impl PluginGroup for DefaultPickingPlugins {
-    fn build(&mut self, group: &mut PluginGroupBuilder) {
-        group.add(PickingPlugin);
-        group.add(InteractablePickingPlugin);
-        HighlightablePickingPlugins.build(group);
+    fn build(self) -> PluginGroupBuilder {
+        PluginGroupBuilder::start::<Self>()
+            .add(PickingPlugin)
+            .add(InteractablePickingPlugin)
     }
 }
 
@@ -168,9 +168,10 @@ impl Plugin for InteractablePickingPlugin {
 
 pub struct HighlightablePickingPlugins;
 impl PluginGroup for HighlightablePickingPlugins {
-    fn build(&mut self, group: &mut PluginGroupBuilder) {
-        group.add(CustomHighlightPlugin(StandardMaterialHighlight));
-        group.add(CustomHighlightPlugin(ColorMaterialHighlight));
+    fn build(self) -> PluginGroupBuilder {
+        PluginGroupBuilder::start::<Self>()
+            .add(CustomHighlightPlugin(StandardMaterialHighlight))
+            .add(CustomHighlightPlugin(ColorMaterialHighlight))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@ impl PluginGroup for DefaultPickingPlugins {
         PluginGroupBuilder::start::<Self>()
             .add(PickingPlugin)
             .add(InteractablePickingPlugin)
+            .add(CustomHighlightPlugin(StandardMaterialHighlight))
+            .add(CustomHighlightPlugin(ColorMaterialHighlight))
     }
 }
 
@@ -163,15 +165,6 @@ impl Plugin for InteractablePickingPlugin {
                             .after(PickingSystem::Selection),
                     ),
             );
-    }
-}
-
-pub struct HighlightablePickingPlugins;
-impl PluginGroup for HighlightablePickingPlugins {
-    fn build(self) -> PluginGroupBuilder {
-        PluginGroupBuilder::start::<Self>()
-            .add(CustomHighlightPlugin(StandardMaterialHighlight))
-            .add(CustomHighlightPlugin(ColorMaterialHighlight))
     }
 }
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -3,7 +3,7 @@ use bevy::{
     prelude::*,
     render::camera::{Camera, RenderTarget},
 };
-use bevy_mod_raycast::RayCastMethod;
+use bevy_mod_raycast::RaycastMethod;
 
 /// Update Screenspace ray cast sources with the current mouse position
 pub fn update_pick_source_positions(
@@ -29,15 +29,15 @@ pub fn update_pick_source_positions(
             UpdatePicks::EveryFrame(cached_cursor_pos) => {
                 match cursor_latest {
                     Some(cursor_moved) => {
-                        pick_source.cast_method = RayCastMethod::Screenspace(cursor_moved);
+                        pick_source.cast_method = RaycastMethod::Screenspace(cursor_moved);
                         *update_picks = UpdatePicks::EveryFrame(cursor_moved);
                     }
-                    None => pick_source.cast_method = RayCastMethod::Screenspace(cached_cursor_pos),
+                    None => pick_source.cast_method = RaycastMethod::Screenspace(cached_cursor_pos),
                 };
             }
             UpdatePicks::OnMouseEvent => match cursor_latest {
                 Some(cursor_moved) => {
-                    pick_source.cast_method = RayCastMethod::Screenspace(cursor_moved)
+                    pick_source.cast_method = RaycastMethod::Screenspace(cursor_moved)
                 }
                 None => continue,
             },


### PR DESCRIPTION
@aevyrie I prepared a small PR which updates some of the deprecated Bevy APIs. Let me know if that's ok, any feedback appreciated.

- use spawn() instead of spawn_bundle()
- use insert() instead of insert_bundle()
- use new DefaultPlugins API

I split the `HighlightablePickingPlugins` from being a part of `DefaultPickingPlugins` I was not sure what would be a better alternative to merging two plugin groups in the PluginGroup::build trait implementation. Is that ok or do you have a suggestion on what to do there?

