### PR TITLE
Use released version of bevy_rapier3d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bevy = { version = "0.9", default-features = false, features = [
     "bevy_ui",
 ] }
 bevy_egui = { optional = true, version = "0.18.0" }
-bevy_rapier3d = { optional = true, git = "https://github.com/devil-ira/bevy_rapier", branch = "bevy-0.9" }
+bevy_rapier3d = { optional = true, version = "0.20.0" }
 
 # Local
 bevy_picking_core = { path = "crates/bevy_picking_core" }

--- a/backends/bevy_picking_rapier/Cargo.toml
+++ b/backends/bevy_picking_rapier/Cargo.toml
@@ -8,6 +8,6 @@ resolver = "2"
 
 [dependencies]
 bevy = { version = "0.9", default-features = false, features = ["bevy_render"] }
-bevy_rapier3d = { git = "https://github.com/devil-ira/bevy_rapier", branch = "bevy-0.9" }
+bevy_rapier3d = "0.20.0"
 # Local
 bevy_picking_core = { path = "../../crates/bevy_picking_core" }


### PR DESCRIPTION
Now that there is a published version of rapier compatible with bevy 0.9,
there is no reason to depend on ira's fork.