### PR TITLE
Forward PointerButton in events

### DIFF
--- a/crates/bevy_picking_core/src/output.rs
+++ b/crates/bevy_picking_core/src/output.rs
@@ -599,7 +599,7 @@ pub fn send_click_and_drag_events(
 ) {
     // Only triggers when over an entity
     for move_event in pointer_move.iter() {
-        for button in PointerButton::all_buttons() {
+        for button in PointerButton::iter() {
             let moving_pointer_is_down = matches!(
                 down_map.get(&(move_event.pointer_id(), button)),
                 Some(Some(_))
@@ -623,7 +623,7 @@ pub fn send_click_and_drag_events(
 
     // Triggers during movement even if not over an entity
     for move_event in input_move.iter() {
-        for button in PointerButton::all_buttons() {
+        for button in PointerButton::iter() {
             if let Some(Some(_)) = down_map.get(&(move_event.pointer_id(), button)) {
                 if let Some(Some(drag_entity)) = drag_map.get(&(move_event.pointer_id(), button)) {
                     pointer_drag.send(PointerDrag::new(
@@ -701,7 +701,7 @@ pub fn send_drag_over_events(
 ) {
     // Fire PointerDragEnter events.
     for over_event in pointer_over.iter() {
-        for button in PointerButton::all_buttons() {
+        for button in PointerButton::iter() {
             if let Some(&Some(dragged)) = drag_map.get(&(over_event.pointer_id(), button)) {
                 if over_event.target() != dragged {
                     let drag_entry = drag_over_map
@@ -719,7 +719,7 @@ pub fn send_drag_over_events(
     }
     // Fire PointerDragOver events.
     for move_event in pointer_move.iter() {
-        for button in PointerButton::all_buttons() {
+        for button in PointerButton::iter() {
             if let Some(&Some(dragged)) = drag_map.get(&(move_event.pointer_id(), button)) {
                 if move_event.target() != dragged {
                     pointer_drag_over.send(PointerDragOver::new(
@@ -760,7 +760,7 @@ pub fn send_drag_over_events(
     for out_event in pointer_out.iter() {
         let out_pointer = out_event.pointer_id();
         let out_target = &out_event.target();
-        for button in PointerButton::all_buttons() {
+        for button in PointerButton::iter() {
             if let Some(dragged_over) = drag_over_map.get_mut(&(out_pointer, button)) {
                 if dragged_over.take(out_target).is_some() {
                     if let Some(&Some(dragged)) = drag_map.get(&(out_pointer, button)) {

--- a/crates/bevy_picking_core/src/output.rs
+++ b/crates/bevy_picking_core/src/output.rs
@@ -600,20 +600,22 @@ pub fn send_click_and_drag_events(
     // Only triggers when over an entity
     for move_event in pointer_move.iter() {
         for button in PointerButton::all_buttons() {
-            let moving_pointer_is_down =
-                matches!(down_map.get(&(move_event.pointer_id(), button)), Some(Some(_)));
+            let moving_pointer_is_down = matches!(
+                down_map.get(&(move_event.pointer_id(), button)),
+                Some(Some(_))
+            );
 
-            let pointer_not_in_drag_map =
-                matches!(drag_map.get(&(move_event.pointer_id(), button)), Some(None) | None);
+            let pointer_not_in_drag_map = matches!(
+                drag_map.get(&(move_event.pointer_id(), button)),
+                Some(None) | None
+            );
 
             if moving_pointer_is_down && pointer_not_in_drag_map {
                 drag_map.insert((move_event.pointer_id(), button), Some(move_event.target()));
                 pointer_drag_start.send(PointerDragStart::new(
                     &move_event.pointer_id(),
                     &move_event.target(),
-                        DragStart {
-                            button: button,
-                        },
+                    DragStart { button: button },
                 ))
             }
         }
@@ -622,18 +624,16 @@ pub fn send_click_and_drag_events(
     // Triggers during movement even if not over an entity
     for move_event in input_move.iter() {
         for button in PointerButton::all_buttons() {
-        if let Some(Some(_)) = down_map.get(&(move_event.pointer_id(), button)) {
-            if let Some(Some(drag_entity)) = drag_map.get(&(move_event.pointer_id(), button)) {
-                pointer_drag.send(PointerDrag::new(
-                    &move_event.pointer_id(),
-                    drag_entity,
-                    Drag {
-                        button,
-                    },
-                ))
+            if let Some(Some(_)) = down_map.get(&(move_event.pointer_id(), button)) {
+                if let Some(Some(drag_entity)) = drag_map.get(&(move_event.pointer_id(), button)) {
+                    pointer_drag.send(PointerDrag::new(
+                        &move_event.pointer_id(),
+                        drag_entity,
+                        Drag { button },
+                    ))
+                }
             }
         }
-    }
     }
 
     for event in pointer_up.iter() {
@@ -644,18 +644,14 @@ pub fn send_click_and_drag_events(
                 pointer_click.send(PointerClick::new(
                     &event.pointer_id(),
                     &event.target(),
-                    Click {
-                        button,
-                    },
+                    Click { button },
                 ));
             }
             if let Some(Some(drag_entity)) = drag_map.get(&(event.pointer_id(), button)) {
                 pointer_drag_end.send(PointerDragEnd::new(
                     &event.pointer_id(),
                     drag_entity,
-                    DragEnd {
-                        button,
-                    },
+                    DragEnd { button },
                 ));
             }
             drag_map.insert((event.pointer_id(), button), None);
@@ -670,7 +666,9 @@ pub fn send_click_and_drag_events(
 
     for press in input_presses.iter() {
         if press.direction() == pointer::PressDirection::Up {
-            if let Some(Some(drag_entity)) = drag_map.insert((press.pointer_id(), press.button()), None) {
+            if let Some(Some(drag_entity)) =
+                drag_map.insert((press.pointer_id(), press.button()), None)
+            {
                 pointer_drag_end.send(PointerDragEnd::new(
                     &press.pointer_id(),
                     &drag_entity,
@@ -703,34 +701,35 @@ pub fn send_drag_over_events(
 ) {
     // Fire PointerDragEnter events.
     for over_event in pointer_over.iter() {
-
         for button in PointerButton::all_buttons() {
-        if let Some(&Some(dragged)) = drag_map.get(&(over_event.pointer_id(), button)) {
-            if over_event.target() != dragged {
-                let drag_entry = drag_over_map.entry((over_event.pointer_id(), button)).or_default();
-                drag_entry.insert(over_event.target());
-                pointer_drag_enter.send(PointerDragEnter::new(
-                    &over_event.pointer_id(),
-                    &over_event.target(),
-                    DragEnter { button, dragged },
-                ))
+            if let Some(&Some(dragged)) = drag_map.get(&(over_event.pointer_id(), button)) {
+                if over_event.target() != dragged {
+                    let drag_entry = drag_over_map
+                        .entry((over_event.pointer_id(), button))
+                        .or_default();
+                    drag_entry.insert(over_event.target());
+                    pointer_drag_enter.send(PointerDragEnter::new(
+                        &over_event.pointer_id(),
+                        &over_event.target(),
+                        DragEnter { button, dragged },
+                    ))
+                }
             }
         }
-    }
     }
     // Fire PointerDragOver events.
     for move_event in pointer_move.iter() {
         for button in PointerButton::all_buttons() {
-        if let Some(&Some(dragged)) = drag_map.get(&(move_event.pointer_id(), button)) {
-            if move_event.target() != dragged {
-                pointer_drag_over.send(PointerDragOver::new(
-                    &move_event.pointer_id(),
-                    &move_event.target(),
-                    DragOver { button, dragged },
-                ))
+            if let Some(&Some(dragged)) = drag_map.get(&(move_event.pointer_id(), button)) {
+                if move_event.target() != dragged {
+                    pointer_drag_over.send(PointerDragOver::new(
+                        &move_event.pointer_id(),
+                        &move_event.target(),
+                        DragOver { button, dragged },
+                    ))
+                }
             }
         }
-    }
     }
     // Fire PointerDragLeave and PointerDrop events when the pointer stops dragging.
     for drag_end_event in pointer_drag_end.iter() {
@@ -762,17 +761,17 @@ pub fn send_drag_over_events(
         let out_pointer = out_event.pointer_id();
         let out_target = &out_event.target();
         for button in PointerButton::all_buttons() {
-        if let Some(dragged_over) = drag_over_map.get_mut(&(out_pointer, button)) {
-            if dragged_over.take(out_target).is_some() {
-                if let Some(&Some(dragged)) = drag_map.get(&(out_pointer, button)) {
-                    pointer_drag_leave.send(PointerDragLeave::new(
-                        &out_pointer,
-                        out_target,
-                        DragLeave { button, dragged },
-                    ))
+            if let Some(dragged_over) = drag_over_map.get_mut(&(out_pointer, button)) {
+                if dragged_over.take(out_target).is_some() {
+                    if let Some(&Some(dragged)) = drag_map.get(&(out_pointer, button)) {
+                        pointer_drag_leave.send(PointerDragLeave::new(
+                            &out_pointer,
+                            out_target,
+                            DragLeave { button, dragged },
+                        ))
+                    }
                 }
             }
         }
-    }
     }
 }

--- a/crates/bevy_picking_core/src/output.rs
+++ b/crates/bevy_picking_core/src/output.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     focus::{HoverMap, PreviousHoverMap},
-    pointer::{self, InputMove, InputPress, PointerId, PressDirection, PointerButton},
+    pointer::{self, InputMove, InputPress, PointerButton, PointerId, PressDirection},
 };
 use bevy::{
     ecs::{event::Event, system::EntityCommands},

--- a/crates/bevy_picking_core/src/output.rs
+++ b/crates/bevy_picking_core/src/output.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     focus::{HoverMap, PreviousHoverMap},
-    pointer::{self, InputMove, InputPress, PointerId, PressDirection},
+    pointer::{self, InputMove, InputPress, PointerId, PressDirection, PointerButton},
 };
 use bevy::{
     ecs::{event::Event, system::EntityCommands},
@@ -335,20 +335,29 @@ pub struct Out;
 pub type PointerDown = PointerEvent<Down>;
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Reflect)]
 /// The inner [`PointerEvent`] type for [`PointerDown`].
-pub struct Down;
+pub struct Down {
+    /// Pointer button pressed to trigger this event.
+    pub button: PointerButton,
+}
 
 /// Fires when a the pointer primary button is released over the `target` entity.
 pub type PointerUp = PointerEvent<Up>;
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Reflect)]
 /// The inner [`PointerEvent`] type for [`PointerUp`].
-pub struct Up;
+pub struct Up {
+    /// Pointer button lifted to trigger this event.
+    pub button: PointerButton,
+}
 
 /// Fires when a pointer sends a pointer down event followed by a pointer up event, with the same
 /// `target` entity for both events.
 pub type PointerClick = PointerEvent<Click>;
 /// The inner [`PointerEvent`] type for [`PointerClick`].
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Reflect)]
-pub struct Click;
+pub struct Click {
+    /// Pointer button pressed and lifted to trigger this event.
+    pub button: PointerButton,
+}
 
 /// Fires while a pointer is moving over the `target` entity.
 pub type PointerMove = PointerEvent<Move>;
@@ -451,7 +460,9 @@ pub fn pointer_events(
                 pointer_up.send(PointerUp::new(
                     &press_event.pointer_id(),
                     hovered_entity,
-                    Up,
+                    Up {
+                        button: press_event.button(),
+                    },
                 ))
             }
         }
@@ -464,7 +475,9 @@ pub fn pointer_events(
                 pointer_down.send(PointerDown::new(
                     &press_event.pointer_id(),
                     hovered_entity,
-                    Down,
+                    Down {
+                        button: press_event.button(),
+                    },
                 ))
             }
         }
@@ -604,7 +617,9 @@ pub fn send_click_and_drag_events(
                 pointer_click.send(PointerClick::new(
                     &event.pointer_id(),
                     &event.target(),
-                    Click,
+                    Click {
+                        button: event.event.button,
+                    },
                 ));
             }
             if let Some(Some(drag_entity)) = drag_map.get(&event.pointer_id()) {

--- a/crates/bevy_picking_core/src/output.rs
+++ b/crates/bevy_picking_core/src/output.rs
@@ -615,7 +615,7 @@ pub fn send_click_and_drag_events(
                 pointer_drag_start.send(PointerDragStart::new(
                     &move_event.pointer_id(),
                     &move_event.target(),
-                    DragStart { button: button },
+                    DragStart { button },
                 ))
             }
         }

--- a/crates/bevy_picking_core/src/pointer.rs
+++ b/crates/bevy_picking_core/src/pointer.rs
@@ -193,7 +193,7 @@ pub enum PointerButton {
 
 impl PointerButton {
     /// Iterator over all buttons that a pointer can have.
-    pub fn all_buttons() -> impl Iterator<Item = PointerButton> {
+    pub fn iter() -> impl Iterator<Item = PointerButton> {
         [Self::Primary, Self::Secondary, Self::Middle].into_iter()
     }
 }

--- a/crates/bevy_picking_core/src/pointer.rs
+++ b/crates/bevy_picking_core/src/pointer.rs
@@ -181,7 +181,7 @@ pub enum PressDirection {
 }
 
 /// The button that was just pressed or released
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 pub enum PointerButton {
     /// The primary pointer button
     Primary,
@@ -189,6 +189,13 @@ pub enum PointerButton {
     Secondary,
     /// The tertiary pointer button
     Middle,
+}
+
+impl PointerButton {
+    /// Iterator over all buttons that a pointer can have.
+    pub fn all_buttons() -> impl Iterator<Item = PointerButton> {
+        [Self::Primary, Self::Secondary, Self::Middle].into_iter()
+    }
 }
 
 /// Component that tracks a pointer's current [`Location`].

--- a/crates/bevy_picking_core/src/pointer.rs
+++ b/crates/bevy_picking_core/src/pointer.rs
@@ -181,7 +181,7 @@ pub enum PressDirection {
 }
 
 /// The button that was just pressed or released
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 pub enum PointerButton {
     /// The primary pointer button
     Primary,

--- a/examples/tinted_highlight.rs
+++ b/examples/tinted_highlight.rs
@@ -70,7 +70,7 @@ fn setup(
         },
         PickableBundle::default(),    // <- Makes the mesh pickable.
         PickRaycastTarget::default(), // <- Needed for the raycast backend.
-        tinted_highlight.clone(),
+        tinted_highlight,
     ));
 
     // light


### PR DESCRIPTION
lets us filter events that we don't care about, e.g. I only care about the primary click in bevy_editor_pls for picking