### PR TITLE
Migrate to bevy 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { version = "0.10.0", default-features = false, features = ["bevy_render"] }
+bevy = { version = "0.10.0", default-features = false, features = ["bevy_render", "bevy_ui"] }
 
 bevy_mod_raycast = {git = "https://github.com/soerenmeier/bevy_mod_raycast", branch = "bevy-0.10"}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { version = "0.9", default-features = false, features = ["render"] }
+bevy = { version = "0.10.0", default-features = false, features = ["bevy_render"] }
 
-bevy_mod_raycast = "0.7"
+bevy_mod_raycast = {git = "https://github.com/soerenmeier/bevy_mod_raycast", branch = "bevy-0.10"}
 
 [dev-dependencies]
-bevy = { version = "0.9", default-features = false, features = [
+bevy = { version = "0.10.0", default-features = false, features = [
     "bevy_pbr",
     "bevy_winit",
     "bevy_ui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,12 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { version = "0.10.0", default-features = false, features = ["bevy_render", "bevy_ui"] }
+bevy = { version = "0.10.0", default-features = false, features = [
+    "bevy_render",
+    "bevy_ui",
+] }
 
-bevy_mod_raycast = {git = "https://github.com/soerenmeier/bevy_mod_raycast", branch = "bevy-0.10"}
+bevy_mod_raycast = "0.8"
 
 [dev-dependencies]
 bevy = { version = "0.10.0", default-features = false, features = [

--- a/examples/deselection.rs
+++ b/examples/deselection.rs
@@ -6,10 +6,10 @@ use bevy_mod_picking::{DefaultPickingPlugins, NoDeselect, PickableBundle, Pickin
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
-            window: WindowDescriptor {
+            primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync, // Reduce input latency
                 ..default()
-            },
+            }),
             ..default()
         }))
         .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
@@ -26,7 +26,7 @@ fn setup(
     // plane
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+            mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
         },

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
         .add_startup_system(setup)
-        .add_system_to_stage(CoreStage::PostUpdate, print_events)
+        .add_system(print_events.in_base_set(CoreSet::PreUpdate))
         .run();
 }
 
@@ -28,7 +28,7 @@ fn setup(
 ) {
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+            mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
         },

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
         .add_startup_system(setup)
-        .add_system(print_events.in_base_set(CoreSet::PreUpdate))
+        .add_system(print_events.in_base_set(CoreSet::PostUpdate))
         .run();
 }
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -8,10 +8,10 @@ use bevy_mod_picking::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
-            window: WindowDescriptor {
+            primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync, // Reduce input latency
                 ..default()
-            },
+            }),
             ..default()
         }))
         .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
@@ -29,7 +29,7 @@ fn setup(
 ) {
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+            mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
         },

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -8,13 +8,12 @@ use bevy_mod_picking::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
-            window: WindowDescriptor {
+            primary_window: Some(Window {
                 title: "bevy_mod_picking stress test".to_string(),
-                width: 800.,
-                height: 600.,
+                resolution: (800., 600.).into(),
                 present_mode: PresentMode::AutoNoVsync, // Reduce input latency
                 ..default()
-            },
+            }),
             ..default()
         }))
         .add_plugins(DefaultPickingPlugins) // <- Adds picking, interaction, and highlighting
@@ -36,10 +35,10 @@ fn setup(
     let tris_total = tris_sphere * (half_width as usize * 2).pow(3);
     info!("Total tris: {}, Tris per mesh: {}", tris_total, tris_sphere);
 
-    let mesh_handle = meshes.add(Mesh::from(shape::Icosphere {
+    let mesh_handle = meshes.add(Mesh::try_from(shape::Icosphere {
         radius: 0.2,
         subdivisions,
-    }));
+    }).unwrap());
 
     let matl_handle = materials.add(StandardMaterial {
         perceptual_roughness: 0.5,

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -35,10 +35,13 @@ fn setup(
     let tris_total = tris_sphere * (half_width as usize * 2).pow(3);
     info!("Total tris: {}, Tris per mesh: {}", tris_total, tris_sphere);
 
-    let mesh_handle = meshes.add(Mesh::try_from(shape::Icosphere {
-        radius: 0.2,
-        subdivisions,
-    }).unwrap());
+    let mesh_handle = meshes.add(
+        Mesh::try_from(shape::Icosphere {
+            radius: 0.2,
+            subdivisions,
+        })
+        .unwrap(),
+    );
 
     let matl_handle = materials.add(StandardMaterial {
         perceptual_roughness: 0.5,

--- a/src/events.rs
+++ b/src/events.rs
@@ -29,18 +29,12 @@ pub fn mesh_events_system(
     mouse_button_input: Res<Input<MouseButton>>,
     touches_input: Res<Touches>,
     mut picking_events: EventWriter<PickingEvent>,
-    hover_query: Query<
-        (Entity, &Hover, ChangeTrackers<Hover>),
-        (Changed<Hover>, With<PickableMesh>),
-    >,
-    selection_query: Query<
-        (Entity, &Selection, ChangeTrackers<Selection>),
-        (Changed<Selection>, With<PickableMesh>),
-    >,
+    hover_query: Query<(Entity, Ref<Hover>), (Changed<Hover>, With<PickableMesh>)>,
+    selection_query: Query<(Entity, Ref<Selection>), (Changed<Selection>, With<PickableMesh>)>,
     click_query: Query<(Entity, &Hover)>,
 ) {
-    for (entity, hover, hover_change) in hover_query.iter() {
-        if hover_change.is_added() {
+    for (entity, hover) in hover_query.iter() {
+        if hover.is_added() {
             continue; // Avoid a false change detection when a component is added.
         }
         if hover.hovered() {
@@ -49,8 +43,8 @@ pub fn mesh_events_system(
             picking_events.send(PickingEvent::Hover(HoverEvent::JustLeft(entity)));
         }
     }
-    for (entity, selection, selection_change) in selection_query.iter() {
-        if selection_change.is_added() {
+    for (entity, selection) in selection_query.iter() {
+        if selection.is_added() {
             continue; // Avoid a false change detection when a component is added.
         }
         if selection.selected() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub type PickingCamera = RaycastSource<PickingRaycastSet>;
 /// meshes or ray sources that are being used by the picking plugin can be used by other ray
 /// casting systems because they will have distinct types, e.g.: `RaycastMesh<PickingRaycastSet>`
 /// vs. `RaycastMesh<MySuperCoolRaycastingType>`, and as such wil not result in collisions.
+#[derive(Clone, Reflect)]
 pub struct PickingRaycastSet;
 
 #[derive(Clone, Debug, Resource)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ impl Default for PickingCameraBundle {
     }
 }
 
-#[derive(Bundle, Default)]
+#[derive(Bundle)]
 pub struct PickableBundle {
     pub pickable_mesh: PickableMesh,
     pub interaction: Interaction,
@@ -219,4 +219,17 @@ pub struct PickableBundle {
     pub highlight: Highlight,
     pub selection: Selection,
     pub hover: Hover,
+}
+
+impl Default for PickableBundle {
+    fn default() -> Self {
+        Self {
+            pickable_mesh: default(),
+            interaction: default(),
+            focus_policy: FocusPolicy::Block,
+            highlight: default(),
+            selection: default(),
+            hover: default(),
+        }
+    }
 }

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -2,6 +2,7 @@ use crate::{PickingCamera, UpdatePicks};
 use bevy::{
     prelude::*,
     render::camera::{Camera, RenderTarget},
+    window::WindowRef,
 };
 use bevy_mod_raycast::RaycastMethod;
 
@@ -57,8 +58,12 @@ fn get_inputs<'a>(
     let cursor_latest = match cursor.iter().last() {
         Some(cursor_moved) => {
             if let RenderTarget::Window(window) = camera.target {
-                if cursor_moved.id == window {
-                    Some(cursor_moved.position)
+                if let WindowRef::Entity(camera_entity) = window {
+                    if cursor_moved.window == camera_entity {
+                        Some(cursor_moved.position)
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -2,7 +2,7 @@ use crate::{PickingCamera, UpdatePicks};
 use bevy::{
     prelude::*,
     render::camera::{Camera, RenderTarget},
-    window::{PrimaryWindow, WindowRef},
+    window::PrimaryWindow,
 };
 use bevy_mod_raycast::RaycastMethod;
 


### PR DESCRIPTION
Hi all,

I've tried my hand at migrating this plugin to be compatible with the new Bevy 0.10 version. This is forked from the main branch and not the beta branch, with the intent of getting a working version of this plugin released ASAP.

This is currently in draft phase, as there are a couple outstanding issues. While the changes committed will compile fine, functionality when executing the examples is broken. I am creating this pull request now to seek assistance with fixing this issue before finalising.

I will leave annotations describing the issues requiring resolution. Any and all responses are appreciated :)