### PR TITLE
Bevy 0.11.0-dev compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 members = ["crates/*", "backends/*"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_ui",
@@ -34,7 +34,7 @@ bevy_picking_sprite = { optional = true, path = "backends/bevy_picking_sprite", 
 bevy_picking_egui = { optional = true, path = "backends/bevy_picking_egui", version = "0.1" }
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_winit",
     "x11",
     "bevy_gltf",

--- a/backends/bevy_picking_egui/Cargo.toml
+++ b/backends/bevy_picking_egui/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { version = "0.11.0-dev", default-features = false }
 bevy_egui = "0.20"
 # Local
 bevy_picking_core = { path = "../../crates/bevy_picking_core", version = "0.1" }

--- a/backends/bevy_picking_egui/src/lib.rs
+++ b/backends/bevy_picking_egui/src/lib.rs
@@ -20,11 +20,11 @@ pub struct EguiBackend;
 impl PickingBackend for EguiBackend {}
 impl Plugin for EguiBackend {
     fn build(&self, app: &mut App) {
-        app.add_system(egui_picking.in_set(PickSet::Backend))
+        app.add_systems(PreUpdate, egui_picking.in_set(PickSet::Backend))
             .insert_resource(EguiBackendSettings::default());
 
         #[cfg(feature = "selection")]
-        app.add_system(update_settings.in_base_set(CoreSet::First));
+        app.add_systems(First, update_settings);
     }
 }
 

--- a/backends/bevy_picking_rapier/Cargo.toml
+++ b/backends/bevy_picking_rapier/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_render",
 ] }
 bevy_rapier3d = "0.21"

--- a/backends/bevy_picking_rapier/src/lib.rs
+++ b/backends/bevy_picking_rapier/src/lib.rs
@@ -19,8 +19,8 @@ pub struct RapierBackend;
 impl PickingBackend for RapierBackend {}
 impl Plugin for RapierBackend {
     fn build(&self, app: &mut App) {
-        app.add_system(build_rays_from_pointers.in_set(PickSet::PostInput))
-            .add_systems((update_hits,).chain().in_set(PickSet::Backend));
+        app.add_systems(First, build_rays_from_pointers.in_set(PickSet::PostInput))
+            .add_systems(PreUpdate, (update_hits,).chain().in_set(PickSet::Backend));
     }
 }
 

--- a/backends/bevy_picking_raycast/Cargo.toml
+++ b/backends/bevy_picking_raycast/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_render",
 ] }
 bevy_mod_raycast = "0.8"

--- a/backends/bevy_picking_raycast/src/lib.rs
+++ b/backends/bevy_picking_raycast/src/lib.rs
@@ -20,11 +20,13 @@ impl PickingBackend for RaycastBackend {}
 impl Plugin for RaycastBackend {
     fn build(&self, app: &mut App) {
         app.add_systems(
+            First,
             (build_rays_from_pointers, spawn_raycast_sources)
                 .chain()
                 .in_set(PickSet::PostInput),
         )
         .add_systems(
+            PreUpdate,
             (
                 bevy_mod_raycast::update_raycast::<RaycastPickingSet>,
                 update_hits,
@@ -32,7 +34,7 @@ impl Plugin for RaycastBackend {
                 .chain()
                 .in_set(PickSet::Backend),
         )
-        .add_system(sync_pickable.in_base_set(CoreSet::PostUpdate));
+        .add_systems(PostUpdate, sync_pickable);
     }
 }
 

--- a/backends/bevy_picking_sprite/Cargo.toml
+++ b/backends/bevy_picking_sprite/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_sprite",
     "bevy_ui",
     "bevy_render",

--- a/backends/bevy_picking_sprite/src/lib.rs
+++ b/backends/bevy_picking_sprite/src/lib.rs
@@ -21,7 +21,7 @@ pub struct SpriteBackend;
 impl PickingBackend for SpriteBackend {}
 impl Plugin for SpriteBackend {
     fn build(&self, app: &mut App) {
-        app.add_system(sprite_picking.in_set(PickSet::Backend));
+        app.add_systems(PreUpdate, sprite_picking.in_set(PickSet::Backend));
     }
 }
 

--- a/backends/bevy_picking_ui/Cargo.toml
+++ b/backends/bevy_picking_ui/Cargo.toml
@@ -13,6 +13,6 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { version = "0.11.0-dev", default-features = false }
 # Local
 bevy_picking_core = { path = "../../crates/bevy_picking_core", version = "0.1" }

--- a/backends/bevy_picking_ui/src/lib.rs
+++ b/backends/bevy_picking_ui/src/lib.rs
@@ -19,7 +19,7 @@ pub struct BevyUiBackend;
 impl PickingBackend for BevyUiBackend {}
 impl Plugin for BevyUiBackend {
     fn build(&self, app: &mut App) {
-        app.add_system(ui_picking.in_set(PickSet::Backend));
+        app.add_systems(PreUpdate, ui_picking.in_set(PickSet::Backend));
     }
 }
 

--- a/crates/bevy_picking_core/Cargo.toml
+++ b/crates/bevy_picking_core/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_render",
     "bevy_ui",
     "bevy_asset",

--- a/crates/bevy_picking_core/src/event_listening.rs
+++ b/crates/bevy_picking_core/src/event_listening.rs
@@ -25,6 +25,7 @@ impl<E: IsPointerEvent> Plugin for EventListenerPlugin<E> {
     fn build(&self, app: &mut App) {
         app.insert_resource(EventCallbackGraph::<E>::default())
             .add_systems(
+                PreUpdate,
                 (
                     EventCallbackGraph::<E>::build.run_if(on_event::<PointerEvent<E>>()),
                     event_bubbling::<E>.run_if(on_event::<PointerEvent<E>>()),

--- a/crates/bevy_picking_core/src/lib.rs
+++ b/crates/bevy_picking_core/src/lib.rs
@@ -127,6 +127,7 @@ impl Plugin for CorePlugin {
             .add_event::<pointer::InputMove>()
             .add_event::<backend::PointerHits>()
             .add_systems(
+                PreUpdate,
                 (
                     pointer::update_pointer_map,
                     pointer::InputMove::receive,
@@ -162,6 +163,7 @@ impl Plugin for InteractionPlugin {
             .add_event::<PointerEvent<DragLeave>>()
             .add_event::<PointerEvent<Drop>>()
             .add_systems(
+                PreUpdate,
                 (
                     update_focus,
                     pointer_events,
@@ -172,7 +174,10 @@ impl Plugin for InteractionPlugin {
                     .chain()
                     .in_set(PickSet::Focus),
             )
-            .configure_set(PickSet::Focus.run_if(PickingPluginsSettings::interaction_should_run));
+            .configure_set(
+                PreUpdate,
+                PickSet::Focus.run_if(PickingPluginsSettings::interaction_should_run),
+            );
 
         app.add_plugin(EventListenerPlugin::<Over>::default())
             .add_plugin(EventListenerPlugin::<Out>::default())
@@ -188,24 +193,21 @@ impl Plugin for InteractionPlugin {
             .add_plugin(EventListenerPlugin::<DragLeave>::default())
             .add_plugin(EventListenerPlugin::<Drop>::default())
             .configure_set(
+                PreUpdate,
                 PickSet::EventListeners.run_if(PickingPluginsSettings::interaction_should_run),
             );
 
-        app.configure_sets(
-            (PickSet::Input, PickSet::PostInput)
-                .chain()
-                .in_base_set(CoreSet::First),
-        )
-        .configure_sets(
-            (
-                PickSet::ProcessInput,
-                PickSet::Backend,
-                PickSet::Focus,
-                PickSet::EventListeners,
-                PickSet::Last,
-            )
-                .chain()
-                .in_base_set(CoreSet::PreUpdate),
-        );
+        app.configure_sets(First, (PickSet::Input, PickSet::PostInput).chain())
+            .configure_sets(
+                PreUpdate,
+                (
+                    PickSet::ProcessInput,
+                    PickSet::Backend,
+                    PickSet::Focus,
+                    PickSet::EventListeners,
+                    PickSet::Last,
+                )
+                    .chain(),
+            );
     }
 }

--- a/crates/bevy_picking_core/src/pointer.rs
+++ b/crates/bevy_picking_core/src/pointer.rs
@@ -295,7 +295,7 @@ impl Location {
 
         camera
             .logical_viewport_rect()
-            .map(|(min, max)| {
+            .map(|Rect { min, max }| {
                 (position - min).min_element() >= 0.0 && (position - max).max_element() <= 0.0
             })
             .unwrap_or(false)

--- a/crates/bevy_picking_highlight/Cargo.toml
+++ b/crates/bevy_picking_highlight/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 bevy_picking_core = { path = "../bevy_picking_core", version = "0.1" }
 bevy_picking_input = { path = "../bevy_picking_input", version = "0.1" }
 bevy_picking_selection = { optional = true, path = "../bevy_picking_selection", version = "0.1" }
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_render",
     "bevy_asset",
 ] }

--- a/crates/bevy_picking_highlight/src/lib.rs
+++ b/crates/bevy_picking_highlight/src/lib.rs
@@ -67,10 +67,14 @@ where
     fn build(&self, app: &mut App) {
         let highlighting_default = self.highlighting_default;
 
-        app.add_startup_system(move |mut commands: Commands, assets: ResMut<Assets<T>>| {
-            commands.insert_resource(highlighting_default(assets));
-        })
+        app.add_systems(
+            Startup,
+            move |mut commands: Commands, assets: ResMut<Assets<T>>| {
+                commands.insert_resource(highlighting_default(assets));
+            },
+        )
         .add_systems(
+            PreUpdate,
             (
                 get_initial_highlight_asset::<T>,
                 Highlight::<T>::update_dynamic,

--- a/crates/bevy_picking_input/Cargo.toml
+++ b/crates/bevy_picking_input/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_render",
 ] }
 bevy_picking_core = { path = "../bevy_picking_core", version = "0.1" }

--- a/crates/bevy_picking_input/src/lib.rs
+++ b/crates/bevy_picking_input/src/lib.rs
@@ -26,8 +26,9 @@ pub struct InputPlugin;
 impl Plugin for InputPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<InputPluginSettings>()
-            .add_startup_system(mouse::spawn_mouse_pointer)
+            .add_systems(Startup, mouse::spawn_mouse_pointer)
             .add_systems(
+                First,
                 (
                     touch::touch_pick_events.run_if(touch_enabled),
                     mouse::mouse_pick_events.run_if(mouse_enabled),
@@ -39,10 +40,9 @@ impl Plugin for InputPlugin {
                     .chain()
                     .in_set(PickSet::Input),
             )
-            .add_system(
-                touch::deactivate_pointers
-                    .in_base_set(CoreSet::Last)
-                    .run_if(PickingPluginsSettings::input_enabled),
+            .add_systems(
+                Last,
+                touch::deactivate_pointers.run_if(PickingPluginsSettings::input_enabled),
             );
     }
 }

--- a/crates/bevy_picking_input/src/touch.rs
+++ b/crates/bevy_picking_input/src/touch.rs
@@ -66,7 +66,7 @@ pub fn touch_pick_events(
                 }
                 location_cache.insert(touch.id, *touch);
             }
-            TouchPhase::Ended | TouchPhase::Cancelled => {
+            TouchPhase::Ended | TouchPhase::Canceled => {
                 input_presses.send(InputPress::new_up(pointer, PointerButton::Primary));
                 location_cache.remove(&touch.id);
                 cancel_events.send(PointerCancel {
@@ -89,7 +89,7 @@ pub fn deactivate_pointers(
 ) {
     for touch in touches.iter() {
         match touch.phase {
-            TouchPhase::Ended | TouchPhase::Cancelled => {
+            TouchPhase::Ended | TouchPhase::Canceled => {
                 for (entity, pointer) in &pointers {
                     if pointer.get_touch_id() == Some(touch.id) {
                         despawn_list.insert((entity, *pointer));

--- a/crates/bevy_picking_selection/Cargo.toml
+++ b/crates/bevy_picking_selection/Cargo.toml
@@ -14,6 +14,6 @@ resolver = "2"
 
 [dependencies]
 bevy_picking_core = { path = "../bevy_picking_core", version = "0.1" }
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_render",
 ] }

--- a/crates/bevy_picking_selection/src/lib.rs
+++ b/crates/bevy_picking_selection/src/lib.rs
@@ -39,6 +39,7 @@ impl Plugin for SelectionPlugin {
             .add_event::<PointerEvent<Select>>()
             .add_event::<PointerEvent<Deselect>>()
             .add_systems(
+                PreUpdate,
                 (
                     multiselect_events.run_if(|settings: Res<SelectionSettings>| {
                         settings.use_multiselect_default_inputs
@@ -48,6 +49,7 @@ impl Plugin for SelectionPlugin {
                     .in_set(PickSet::ProcessInput),
             )
             .add_systems(
+                PreUpdate,
                 (
                     send_selection_events,
                     bevy_picking_core::event_listening::event_bubbling::<Select>,

--- a/examples/bevy_ui.rs
+++ b/examples/bevy_ui.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
-        .add_startup_system(setup);
+        .add_systems(Startup, setup);
     #[cfg(feature = "backend_egui")]
     app.add_plugin(bevy_egui::EguiPlugin);
     app.run();

--- a/examples/deselection.rs
+++ b/examples/deselection.rs
@@ -8,7 +8,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/drag_and_drop.rs
+++ b/examples/drag_and_drop.rs
@@ -7,8 +7,8 @@ fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
-        .add_startup_system(setup)
-        .add_system(spin);
+        .add_systems(Startup, setup)
+        .add_systems(Update, spin);
     #[cfg(feature = "backend_egui")]
     app.add_plugin(bevy_egui::EguiPlugin);
     app.run();

--- a/examples/drag_and_drop.rs
+++ b/examples/drag_and_drop.rs
@@ -38,7 +38,8 @@ fn setup(
             OnPointer::<DragStart>::target_remove::<Pickable>(), // Disable picking
             OnPointer::<DragEnd>::target_insert(Pickable), // Re-enable picking
             OnPointer::<Drag>::target_component_mut::<Transform>(|drag, transform| {
-                transform.translation += drag.delta.extend(0.0) // Make the square follow the mouse
+                // Make the square follow the mouse
+                transform.translation += (drag.delta * Vec2::new(1.0, -1.0)).extend(0.0)
             }),
             OnPointer::<Drop>::commands_mut(|event, commands| {
                 commands.entity(event.dropped).insert(Spin(FRAC_PI_2)); // Spin dropped entity

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -16,8 +16,8 @@ fn main() {
         .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
         .add_plugin(EguiPlugin)
-        .add_system(ui_example)
-        .add_startup_system(setup)
+        .add_systems(Update, ui_example)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -16,9 +16,12 @@ fn main() {
                 .disable::<DefaultHighlightingPlugin>(),
         )
         .add_plugin(bevy_egui::EguiPlugin)
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .add_event::<DoSomethingComplex>()
-        .add_system(receive_greetings.run_if(on_event::<DoSomethingComplex>()))
+        .add_systems(
+            Update,
+            receive_greetings.run_if(on_event::<DoSomethingComplex>()),
+        )
         .run();
 }
 

--- a/examples/gltf.rs
+++ b/examples/gltf.rs
@@ -14,8 +14,8 @@ fn main() {
                 .build()
                 .disable::<DebugPickingPlugin>(),
         )
-        .add_startup_system(setup)
-        .add_system(make_pickable)
+        .add_systems(Startup, setup)
+        .add_systems(Update, make_pickable)
         .run();
 }
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/minimal_2d.rs
+++ b/examples/minimal_2d.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -8,7 +8,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
         .add_plugin(bevy_egui::EguiPlugin) //  For debug: bevy_ui does not support multiple windows.
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/rapier.rs
+++ b/examples/rapier.rs
@@ -11,7 +11,7 @@ fn main() {
         .add_plugins(DefaultPickingPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -8,8 +8,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
-        .add_startup_system(setup)
-        .add_system(move_sprite)
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_sprite)
         .run();
 }
 

--- a/examples/tinted_highlight.rs
+++ b/examples/tinted_highlight.rs
@@ -8,7 +8,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/two_passes.rs
+++ b/examples/two_passes.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/virtual_pointer.rs
+++ b/examples/virtual_pointer.rs
@@ -14,8 +14,8 @@ fn main() {
         .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         .add_plugins(DefaultPickingPlugins)
         .add_plugin(bevy_egui::EguiPlugin) // Nicer pointer debug overlay, useful for this example.
-        .add_startup_system(setup)
-        .add_system(move_virtual_pointer)
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_virtual_pointer)
         .run();
 }
 

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -285,7 +285,7 @@ pub fn debug_draw(
             style: Style {
                 position_type: PositionType::Absolute,
                 left: Val::Px(location.position.x + 5.0),
-                bottom: Val::Px(location.position.y + 5.0),
+                top: Val::Px(location.position.y + 5.0),
                 ..default()
             },
             ..default()

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -28,14 +28,15 @@ impl Plugin for DebugPickingPlugin {
         load_internal_binary_asset!(app, DEBUG_FONT_HANDLE, "FiraMono-Medium.ttf", font_loader);
 
         app.init_resource::<debug::Frame>()
-            .add_system(debug::increment_frame.in_base_set(CoreSet::First))
-            .add_system(
+            .add_systems(First, debug::increment_frame)
+            .add_systems(
+                PreUpdate,
                 input::debug::print
                     .before(picking_core::PickSet::Backend)
-                    .run_if(move || noisy_debug)
-                    .in_base_set(CoreSet::PreUpdate),
+                    .run_if(move || noisy_debug),
             )
             .add_systems(
+                PreUpdate,
                 (
                     debug::print::<events::Over>,
                     debug::print::<events::Out>,
@@ -56,6 +57,7 @@ impl Plugin for DebugPickingPlugin {
 
         #[cfg(not(feature = "backend_egui"))]
         app.add_systems(
+            PreUpdate,
             (add_pointer_debug, update_debug_data, debug_draw)
                 .chain()
                 .in_set(picking_core::PickSet::Last),
@@ -68,10 +70,13 @@ impl Plugin for DebugPickingPlugin {
         );
 
         #[cfg(feature = "selection")]
-        app.add_systems((
-            debug::print::<selection::Select>,
-            debug::print::<selection::Deselect>,
-        ));
+        app.add_systems(
+            Update,
+            (
+                debug::print::<selection::Select>,
+                debug::print::<selection::Deselect>,
+            ),
+        );
     }
 }
 
@@ -279,11 +284,8 @@ pub fn debug_draw(
             ),
             style: Style {
                 position_type: PositionType::Absolute,
-                position: UiRect {
-                    left: Val::Px(location.position.x + 5.0),
-                    bottom: Val::Px(location.position.y + 5.0),
-                    ..default()
-                },
+                left: Val::Px(location.position.x + 5.0),
+                bottom: Val::Px(location.position.y + 5.0),
                 ..default()
             },
             ..default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,6 @@ pub struct PickableBundle {
 /// Bundle of components needed for a fully-featured pointer.
 #[derive(Bundle)]
 pub struct PointerBundle {
-    #[bundle]
     core: PointerCoreBundle,
     #[cfg(feature = "selection")]
     selection: selection::PointerMultiselect,


### PR DESCRIPTION
Hey 👋 

I needed picking for a project targeting the latest current `main` bevy branch, (v0.11.0-dev) so I've updated this crate (and also `bevy_mod_raycast`) to work under it. Here are the breaking changes I had to account for:

- Removal of base sets
- Changes to `.add_systems()`
- Y coordinate of cursor position is no longer flipped

It's likely there will be more breaking changes before the 0.11.0 release; I'll try to keep this PR up-to-date.

## To Do

- [ ] Double check all schedule assignments are indeed correct, I tried my best but there were a lot of them, I might have gotten one or two switched up by mistake. All demos (except alternate backends? see below) seem to be working correctly, though.
- [ ] Get `backend_egui` working (Might need upstream update?)
- [ ] Get `backend_rapier3d` working (Might need upstream update?)

## Related PRs

Raycasting PR: https://github.com/aevyrie/bevy_mod_raycast/pull/78