### PR TITLE
Invert Y axis for touch events

### DIFF
--- a/crates/bevy_picking_input/src/touch.rs
+++ b/crates/bevy_picking_input/src/touch.rs
@@ -20,7 +20,7 @@ use bevy_picking_core::{
 pub fn touch_pick_events(
     // Input
     mut touches: EventReader<TouchInput>,
-    windows: Query<(Entity, &Window), With<PrimaryWindow>>,
+    windows: Query<Entity, With<PrimaryWindow>>,
     // Local
     mut location_cache: Local<HashMap<u64, TouchInput>>,
     // Output
@@ -32,12 +32,11 @@ pub fn touch_pick_events(
     for touch in touches.iter() {
         let pointer = PointerId::Touch(touch.id);
         let pos = touch.position;
-        let height = windows.single().1.height();
         let location = Location {
             target: RenderTarget::Window(WindowRef::Primary)
-                .normalize(Some(windows.single().0))
+                .normalize(Some(windows.single()))
                 .unwrap(),
-            position: Vec2::new(pos.x, height - pos.y),
+            position: Vec2::new(pos.x, pos.y),
         };
         match touch.phase {
             TouchPhase::Started => {


### PR DESCRIPTION
Resolves #221 

I only own one touch device (Android - S11), so this fix was only tested there.

What was the reason for manually inverting the Y axis for touch events?