### PR TITLE
Do not enable bevy_pbr with backend_sprite feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,8 +65,9 @@ selection = [
     "bevy_picking_selection",
     "bevy_picking_input/selection",
     "bevy_picking_highlight/selection",
+    "bevy_picking_highlight/pbr",
 ]
-highlight = ["bevy_picking_highlight"]
+highlight = ["bevy_picking_highlight/pbr"]
 debug = ["bevy/bevy_text", "bevy/bevy_sprite"]
 backend_raycast = ["bevy_picking_raycast"]
 backend_rapier = ["bevy_picking_rapier", "bevy_rapier3d"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ selection = [
     "bevy_picking_selection",
     "bevy_picking_input/selection",
     "bevy_picking_highlight/selection",
-    "bevy_picking_highlight/pbr",
 ]
 highlight = ["bevy_picking_highlight/pbr"]
 debug = ["bevy/bevy_text", "bevy/bevy_sprite"]

--- a/crates/bevy_picking_highlight/Cargo.toml
+++ b/crates/bevy_picking_highlight/Cargo.toml
@@ -22,7 +22,6 @@ bevy = { version = "0.10", default-features = false, features = [
 ] }
 
 [features]
-default = ["pbr"]
 selection = ["bevy_picking_selection"]
 sprite = ["bevy/bevy_sprite"]
 pbr = ["bevy/bevy_pbr"]


### PR DESCRIPTION
I removed the default `pbr` feature from `bevy_picking_highlight` and instead explicitly enabled it for the feature `highlight`.

The `selection` feature would now no longer automatically highlight standard materials.

Resolves #224