### PR TITLE
Add `Inside` to `Pointer` events

### DIFF
--- a/crates/bevy_picking_core/src/lib.rs
+++ b/crates/bevy_picking_core/src/lib.rs
@@ -154,6 +154,7 @@ impl Plugin for InteractionPlugin {
             .add_event::<Pointer<Up>>()
             .add_event::<Pointer<Click>>()
             .add_event::<Pointer<Move>>()
+            .add_event::<Pointer<Inside>>()
             .add_event::<Pointer<DragStart>>()
             .add_event::<Pointer<Drag>>()
             .add_event::<Pointer<DragEnd>>()
@@ -185,6 +186,7 @@ impl Plugin for InteractionPlugin {
             EventListenerPlugin::<Pointer<Up>>::default(),
             EventListenerPlugin::<Pointer<Click>>::default(),
             EventListenerPlugin::<Pointer<Move>>::default(),
+            EventListenerPlugin::<Pointer<Inside>>::default(),
             EventListenerPlugin::<Pointer<DragStart>>::default(),
             EventListenerPlugin::<Pointer<Drag>>::default(),
             EventListenerPlugin::<Pointer<DragEnd>>::default(),

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -86,6 +86,7 @@ impl Plugin for DebugPickingPlugin {
                 debug::print::<events::Up>,
                 debug::print::<events::Click>,
                 debug::print::<events::Move>.run_if(DebugPickingMode::is_noisy),
+                debug::print::<events::Inside>,
                 debug::print::<events::DragStart>,
                 debug::print::<events::Drag>.run_if(DebugPickingMode::is_noisy),
                 debug::print::<events::DragEnd>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ pub mod prelude {
     pub use crate::{
         backends,
         events::{
-            Click, Down, Drag, DragEnd, DragEnter, DragLeave, DragOver, DragStart, Drop,
+            Click, Down, Drag, DragEnd, DragEnter, DragLeave, DragOver, DragStart, Drop, Inside,
             IsPointerEvent, Move, Out, Over, Pointer, Up,
         },
         picking_core::Pickable,


### PR DESCRIPTION
Adds `Inside` to `Pointer`, which fires an event while the pointer is inside an entity. It is mostly the `Over` event, but instead of firing when it enters an entity, it just continues to fire.