### PR TITLE
Fix anchor handling in sprite backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # UNRELEASED
 
+- Fixed: anchor handling in sprite backend.
 - Changed: the bevy_mod_raycast backend no longer requires markers on the camera
   (`RaycastPickCamera`) and targets (`RaycastPickTarget`).
 - Added: `RaycastBackendSettings` resource added to allow toggling the requirement for markers with

--- a/backends/bevy_picking_sprite/src/lib.rs
+++ b/backends/bevy_picking_sprite/src/lib.rs
@@ -76,12 +76,11 @@ pub fn sprite_picking(
                         return None;
                     }
                     let position = sprite_transform.translation();
-                    let half_extents = sprite
+                    let extents = sprite
                         .custom_size
-                        .or_else(|| images.get(image).map(|f| f.size()))
-                        .map(|size| size / 2.0)?;
-                    let center = position.truncate() + (sprite.anchor.as_vec() * half_extents);
-                    let rect = Rect::from_center_half_size(center, half_extents);
+                        .or_else(|| images.get(image).map(|f| f.size()))?;
+                    let center = position.truncate() - (sprite.anchor.as_vec() * extents);
+                    let rect = Rect::from_center_half_size(center, extents / 2.0);
 
                     let is_cursor_in_sprite = rect.contains(cursor_pos_world);
                     blocked = is_cursor_in_sprite

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,13 +90,9 @@
 //! commands.spawn((
 //!     PbrBundle::default(),           // The `bevy_picking_raycast` backend works with meshes
 //!     PickableBundle::default(),      // Makes the entity pickable
-//!     RaycastPickTarget::default()    // Marker for the `bevy_picking_raycast` backend
 //! ));
 //!
-//! commands.spawn((
-//!     Camera3dBundle::default(),
-//!     RaycastPickCamera::default(),   // Enable picking using this camera
-//! ));
+//! commands.spawn(Camera3dBundle::default());
 //! # }
 //! ```
 //!


### PR DESCRIPTION
There is a problem in the sprite backend with handling of the configured anchor. There seems to be a discrepancy in the values of what the `Anchor` values mean and computing the center of the rect.

For instance `Anchor::TopRight` is equivalent to `Anchor::Custom(Vec2::new(0.5, 0.5))`. This means that the "center" is shifted down and left by 0.5 of the extent. Essentially the anchor value handles cutting the extent in half, thus, we need to not divide by 2.0 for the center calculation.

Sorry if I am explaining it badly, I have some example code that I wrote for testing, here:
```rust
//! Tests that sprite anchors are correctly handled.

use bevy::prelude::*;
use bevy_mod_picking::prelude::*;
use bevy::sprite::Anchor;

fn main() {
    App::new()
        .add_plugins((
            DefaultPlugins.set(low_latency_window_plugin()),
            DefaultPickingPlugins,
        ))
        .add_systems(Startup, setup)
        .run();
}

fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
    commands.spawn(Camera2dBundle::default());

    let mut anchor_index = 0;

    for anchor in [
        Anchor::TopLeft,
        Anchor::TopCenter,
        Anchor::TopRight,
        Anchor::CenterLeft,
        Anchor::Center,
        Anchor::CenterRight,
        Anchor::BottomLeft,
        Anchor::BottomCenter,
        Anchor::BottomRight,
        Anchor::Custom(Vec2::new(0.5, 0.5)),
    ] {
        // spawn black square behind sprite to show anchor point
        commands.spawn(SpriteBundle {
            sprite: Sprite {
                custom_size: Some(Vec2::new(128.0, 128.0)),
                color: Color::BLACK,
                ..default()
            },
            transform: Transform::from_xyz(
                (anchor_index % 3) as f32 * 256.0 - 256.0,
                (anchor_index / 3) as f32 * 256.0 - 256.0,
                -1.0,
            ),
            ..default()
        });

        commands.spawn(SpriteBundle {
            sprite: Sprite { 
                custom_size: Some(Vec2::new(128.0, 128.0)),
                color: Color::RED,
                anchor, ..default() },

            // 3x3 grid of anchor examples by changing tranform
            transform: Transform::from_xyz(
                (anchor_index % 3) as f32 * 256.0 - 256.0,
                (anchor_index / 3) as f32 * 256.0 - 256.0,
                0.0,
            ),
            // texture: asset_server.load("images/boovy.png"),
            ..default()
        });
        anchor_index += 1;
    }
}
```