### PR TITLE
Fix hit box of scaled sprites

### DIFF
--- a/backends/bevy_picking_sprite/src/lib.rs
+++ b/backends/bevy_picking_sprite/src/lib.rs
@@ -75,10 +75,10 @@ pub fn sprite_picking(
                     if blocked || !visibility.is_visible() {
                         return None;
                     }
-                    let position = sprite_transform.translation();
+                    let (scale, _rot, position) = sprite_transform.to_scale_rotation_translation();
                     let extents = sprite
                         .custom_size
-                        .or_else(|| images.get(image).map(|f| f.size()))?;
+                        .or_else(|| images.get(image).map(|f| f.size()))? * scale.truncate();
                     let center = position.truncate() - (sprite.anchor.as_vec() * extents);
                     let rect = Rect::from_center_half_size(center, extents / 2.0);
 

--- a/backends/bevy_picking_sprite/src/lib.rs
+++ b/backends/bevy_picking_sprite/src/lib.rs
@@ -76,7 +76,8 @@ pub fn sprite_picking(
                     let (scale, _rot, position) = sprite_transform.to_scale_rotation_translation();
                     let extents = sprite
                         .custom_size
-                        .or_else(|| images.get(image).map(|f| f.size()))? * scale.truncate();
+                        .or_else(|| images.get(image).map(|f| f.size()))?
+                        * scale.truncate();
                     let center = position.truncate() - (sprite.anchor.as_vec() * extents);
                     let rect = Rect::from_center_half_size(center, extents / 2.0);
 

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -55,6 +55,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             .iter()
             .enumerate()
             {
+                let i = (anchor_index % 3) as f32;
+                let j = (anchor_index / 3) as f32;
+
                 // spawn black square behind sprite to show anchor point
                 commands.spawn(SpriteBundle {
                     sprite: Sprite {
@@ -63,8 +66,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ..default()
                     },
                     transform: Transform::from_xyz(
-                        (anchor_index % 3) as f32 * len - len,
-                        (anchor_index / 3) as f32 * len - len,
+                        i * len - len,
+                        j * len - len,
                         -1.0,
                     ),
                     ..default()
@@ -80,9 +83,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     texture: asset_server.load("images/boovy.png"),
                     // 3x3 grid of anchor examples by changing transform
                     transform: Transform::from_xyz(
-                        (anchor_index % 3) as f32 * len - len,
-                        (anchor_index / 3) as f32 * len - len,
+                        i * len - len,
+                        j as f32 * len - len,
                         0.0,
+                    ).with_scale(
+                        Vec3::splat(1.0 + (i - 1.0) * 0.2)
                     ),
                     ..default()
                 });

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -65,11 +65,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         color: Color::BLACK,
                         ..default()
                     },
-                    transform: Transform::from_xyz(
-                        i * len - len,
-                        j * len - len,
-                        -1.0,
-                    ),
+                    transform: Transform::from_xyz(i * len - len, j * len - len, -1.0),
                     ..default()
                 });
 
@@ -82,13 +78,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                     texture: asset_server.load("images/boovy.png"),
                     // 3x3 grid of anchor examples by changing transform
-                    transform: Transform::from_xyz(
-                        i * len - len,
-                        j as f32 * len - len,
-                        0.0,
-                    ).with_scale(
-                        Vec3::splat(1.0 + (i - 1.0) * 0.2)
-                    ),
+                    transform: Transform::from_xyz(i * len - len, j as f32 * len - len, 0.0)
+                        .with_scale(Vec3::splat(1.0 + (i - 1.0) * 0.2)),
                     ..default()
                 });
             }


### PR DESCRIPTION
We want to take into account not only the translation part of the global transform, but also the scaling.  At the moment, rotations are still not dealt with.

I am also not sure how performant the `to_scale_rotation_translation()` method is.  (I think a different API could be faster, because we do not really need the decomposition.)

This should fix issue #234.