### PR TITLE
Support rotated sprites (and rotated hit boxes)

### DIFF
--- a/backends/bevy_picking_sprite/src/lib.rs
+++ b/backends/bevy_picking_sprite/src/lib.rs
@@ -75,10 +75,10 @@ pub fn sprite_picking(
                     if blocked || !visibility.is_visible() {
                         return None;
                     }
-                    let position = sprite_transform.translation();
+                    let (scale, _rot, position) = sprite_transform.to_scale_rotation_translation();
                     let extents = sprite
                         .custom_size
-                        .or_else(|| images.get(image).map(|f| f.size()))?;
+                        .or_else(|| images.get(image).map(|f| f.size()))? * scale.truncate();
                     let center = position.truncate() - (sprite.anchor.as_vec() * extents);
                     let rect = Rect::from_center_half_size(center, extents / 2.0);
 

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -78,7 +78,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                     texture: asset_server.load("images/boovy.png"),
                     // 3x3 grid of anchor examples by changing transform
-                    transform: Transform::from_xyz(i * len - len, j as f32 * len - len, 0.0)
+                    transform: Transform::from_xyz(i * len - len, j * len - len, 0.0)
                         .with_scale(Vec3::splat(1.0 + (i - 1.0) * 0.2))
                         .with_rotation(Quat::from_rotation_z((j - 1.0) * 0.2)),
                     ..default()

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -55,6 +55,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             .iter()
             .enumerate()
             {
+                let i = (anchor_index % 3) as f32;
+                let j = (anchor_index / 3) as f32;
+
                 // spawn black square behind sprite to show anchor point
                 commands.spawn(SpriteBundle {
                     sprite: Sprite {
@@ -63,8 +66,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ..default()
                     },
                     transform: Transform::from_xyz(
-                        (anchor_index % 3) as f32 * len - len,
-                        (anchor_index / 3) as f32 * len - len,
+                        i * len - len,
+                        j * len - len,
                         -1.0,
                     ),
                     ..default()
@@ -80,9 +83,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     texture: asset_server.load("images/boovy.png"),
                     // 3x3 grid of anchor examples by changing transform
                     transform: Transform::from_xyz(
-                        (anchor_index % 3) as f32 * len - len,
-                        (anchor_index / 3) as f32 * len - len,
+                        i * len - len,
+                        j as f32 * len - len,
                         0.0,
+                    ).with_scale(
+                        Vec3::splat(1.0 + (i - 1.0) * 0.2)
                     ),
                     ..default()
                 });

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -88,6 +88,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         0.0,
                     ).with_scale(
                         Vec3::splat(1.0 + (i - 1.0) * 0.2)
+                    ).with_rotation(
+                        Quat::from_rotation_z((j - 1.0) * 0.2)
                     ),
                     ..default()
                 });


### PR DESCRIPTION
This is certainly more expensive than the old code, but also much more correct and future-proof: Inverting the affine transform allows to support rotated sprites as well.

I also adapted the `sprite` example to demonstrate the feature.

I am sure that glam offers very fast Affine3A inversion, yet I think it would be possible to speed this up in theory.  Not sure that caching the inverted transform makes much sense, since many global transforms would be invalidated very often.

On the other hand, we only perform a 2D hit box test, but the affine transform is 3D; one could skip computing the z coordinate AFAICS.

Finally, an option for speedups would be to make the kind of test configurable; if it is known that certain sprites are never rotated (or even scaled), the computation could take a simpler path.  Such configurability would also allow for a more expensive path: Testing the sprite pixmap for transparency at the pointer position would now be a low hanging fruit.