### PR TITLE
Change log level from info to debug and trace

### DIFF
--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -169,7 +169,6 @@ pub fn log_trace<E: Debug + Clone + Reflect>(mut pointer_events: EventReader<Poi
     }
 }
 
-
 /// Adds [`PointerDebug`] to pointers automatically.
 pub fn add_pointer_debug(
     mut commands: Commands,


### PR DESCRIPTION
This implements #259.

Messages linked to the "Noisy" debug state are logged with `trace!()`. The rest are logged with `debug!()`. Filtering on this _could_ replace the Noisy/Normal state distinction entirely (perhaps leaving the DebugPickingMode state _only_ for hiding or showing the cursor text overlay) but I'll leave that possibility for the future. This just makes a minimal change.