### PR TITLE
configurable mapping from Mouse Buttons to Pointer Buttons

### DIFF
--- a/crates/bevy_picking_input/src/lib.rs
+++ b/crates/bevy_picking_input/src/lib.rs
@@ -52,12 +52,16 @@ impl Plugin for InputPlugin {
 pub struct InputPluginSettings {
     run_mouse: bool,
     run_touch: bool,
+    /// Map buttons from Bevy's mouse input (e.g. `MouseButton::Left`) to Pointer
+    /// buttons (e.g. PointerButton::Primary).
+    pub mouse_button_mapping: mouse::MouseButtonMapping,
 }
 impl Default for InputPluginSettings {
     fn default() -> Self {
         Self {
             run_mouse: true,
             run_touch: true,
+            mouse_button_mapping: mouse::MouseButtonMapping::default(),
         }
     }
 }

--- a/crates/bevy_picking_input/src/mouse.rs
+++ b/crates/bevy_picking_input/src/mouse.rs
@@ -13,10 +13,15 @@ use bevy_picking_core::{
     PointerCoreBundle,
 };
 
-/// Map buttons from Bevy's mouse system to pointer buttons. Access through [`InputPluginSettings`].
+/// Map buttons from Bevy's mouse system to pointer buttons.
+///
 /// Note that the values (PointerButton) _must_ be unique, as pressed/released status is tracked
 /// at the higher level, and will get confused with multiple mouse buttons mapped to the same
-/// pointer button.
+/// pointer button. Therefore, when you assign a pointer button to a mouse button with [`set_mapping`],
+/// any existing mappings to that pointer button will be cleared. For example, if you start
+/// from the default and map [`MouseButton::Left`] to [`PointerButton::Secondary`],
+/// [`MouseButton::Right`] will be set to `None`. (You can then call `set_mapping` a second time
+/// to set `MouseButton::Right` to [`PointerButton::Primary`].)
 #[derive(Resource, Debug, Reflect)]
 pub struct MouseButtonSettings {
     mapping: HashMap<MouseButton, Option<PointerButton>>,

--- a/crates/bevy_picking_input/src/mouse.rs
+++ b/crates/bevy_picking_input/src/mouse.rs
@@ -84,11 +84,10 @@ impl MouseButtonSettings {
             }
             None => debug!("Setting {:?} Mouse button to None", mouse_button),
         };
-        if clear.is_some() {
-            self.mapping.insert(clear.unwrap(), None);
+        if let Some(m) = clear {
+            self.mapping.insert(m, None);
         }
-        self.mapping
-            .insert(mouse_button.clone(), pointer_button.clone());
+        self.mapping.insert(mouse_button, pointer_button);
     }
 }
 

--- a/crates/bevy_picking_input/src/mouse.rs
+++ b/crates/bevy_picking_input/src/mouse.rs
@@ -15,13 +15,14 @@ use bevy_picking_core::{
 
 /// Map buttons from Bevy's mouse system to pointer buttons.
 ///
-/// Note that the values (PointerButton) _must_ be unique, as pressed/released status is tracked
-/// at the higher level, and will get confused with multiple mouse buttons mapped to the same
-/// pointer button. Therefore, when you assign a pointer button to a mouse button with [`set_mapping`],
-/// any existing mappings to that pointer button will be cleared. For example, if you start
-/// from the default and map [`MouseButton::Left`] to [`PointerButton::Secondary`],
-/// [`MouseButton::Right`] will be set to `None`. (You can then call `set_mapping` a second time
-/// to set `MouseButton::Right` to [`PointerButton::Primary`].)
+/// Note that the values (PointerButton) _must_ be unique, as pressed/released status is
+/// tracked at the higher level, and will get confused with multiple mouse buttons mapped
+/// to the same pointer button. Therefore, when you assign a pointer button to a mouse
+/// button with [`MouseButtonSettings::set_mapping()`], any existing mappings to that
+/// pointer button will be cleared. For example, if you start from the default and map
+/// [`MouseButton::Left`] to [`PointerButton::Secondary`], [`MouseButton::Right`] will be
+/// set to `None`. (You can then call `set_mapping` a second time to set
+/// `MouseButton::Right` to [`PointerButton::Primary`].)
 #[derive(Resource, Debug, Reflect)]
 pub struct MouseButtonSettings {
     mapping: HashMap<MouseButton, Option<PointerButton>>,

--- a/examples/swap_mouse_buttons.rs
+++ b/examples/swap_mouse_buttons.rs
@@ -1,0 +1,67 @@
+//! The minimal example, but with the right mouse button as primary,
+//! the left button as secondary, and the middle button not mapped.
+
+use bevy::prelude::*;
+use bevy_mod_picking::prelude::*;
+use input::InputPluginSettings;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
+        // All you need to do is add the picking plugin, with your backend of choice enabled in the
+        // cargo features. By default, the bevy_mod_raycast backend is enabled via the
+        // `backend_raycast` feature.
+        .add_plugins(DefaultPickingPlugins)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+// Spawn a simple scene, like bevy's 3d_scene example.
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut input_plugin_settings: ResMut<InputPluginSettings>,
+) {
+    input_plugin_settings
+        .mouse_button_mapping
+        .set_mapping(MouseButton::Left, Some(PointerButton::Secondary));
+    input_plugin_settings
+        .mouse_button_mapping
+        .set_mapping(MouseButton::Right, Some(PointerButton::Primary));
+    input_plugin_settings
+        .mouse_button_mapping
+        .set_mapping(MouseButton::Middle, None);
+
+    // The rest of this is identical to minimal.rs
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
+            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+            ..default()
+        },
+        PickableBundle::default(), // Adds selection, highlighting, and the `Pickable` override.
+    ));
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0),
+            ..default()
+        },
+        PickableBundle::default(), // Adds selection, highlighting, and the `Pickable` override.
+    ));
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, -4.0),
+        ..default()
+    });
+    commands.spawn((Camera3dBundle {
+        transform: Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    },));
+}


### PR DESCRIPTION
This adds a configurable map to InputPluginSettings. This allows for configuring Right, Left, and Middle buttons as determined by bevy, as well as Other buttons (by number). It does not extend picking to provide target mappings other than Primary, Secondary, and Middle. (That's future work!)

The abstraction here makes it easy for games to provide end-user configuration of the binding. I'm not set on _this_ particular interface to changing it and can update the code for other ideas.

If this is accepted, my next step is to tackle the "other" buttons.