### PR TITLE
Fix ordering bug in SelectionPlugin

### DIFF
--- a/crates/bevy_picking_selection/src/lib.rs
+++ b/crates/bevy_picking_selection/src/lib.rs
@@ -231,7 +231,6 @@ pub fn update_state_from_events(
 ) {
     for selection in selections.iter() {
         if let Ok(mut select_me) = selectables.get_mut(selection.target) {
-            dbg!("mod_picking");
             select_me.is_selected = true;
         }
     }

--- a/crates/bevy_picking_selection/src/lib.rs
+++ b/crates/bevy_picking_selection/src/lib.rs
@@ -53,7 +53,9 @@ impl Plugin for SelectionPlugin {
                     )
                         .chain()
                         .in_set(PickSet::ProcessInput),
-                    (send_selection_events, update_state_from_events).in_set(PickSet::PostFocus),
+                    (send_selection_events, update_state_from_events)
+                        .chain()
+                        .in_set(PickSet::PostFocus),
                 ),
             );
     }
@@ -229,6 +231,7 @@ pub fn update_state_from_events(
 ) {
     for selection in selections.iter() {
         if let Ok(mut select_me) = selectables.get_mut(selection.target) {
+            dbg!("mod_picking");
             select_me.is_selected = true;
         }
     }


### PR DESCRIPTION
`send_selection_events` and `update_state_from_events` not being ordered relative to one another meant that sometimes clicks would be applied to `PickSelection` one frame late, and sometimes not. This led to unreliable and sometimes broken behavior, so we fix their ordering using a `.chain()` call to ensure `PickSelection` is always updated on the frame the pointer is released.