### PR TITLE
Fix the Bevy UI backend so it ignores clipped areas of UI nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 - Added: support for `bevy_ui` `UiScale`.
+- Fixed: the bevy ui backend now ignores clipped areas of UI nodes. 
 - Added: `RaycastBackendSettings::raycast_visibility` to support picking hidden meshes.
 
 # 0.17.0

--- a/backends/bevy_picking_rapier/Cargo.toml
+++ b/backends/bevy_picking_rapier/Cargo.toml
@@ -15,11 +15,9 @@ resolver = "2"
 [dependencies]
 bevy_app = { version = "0.12", default-features = false }
 bevy_ecs = { version = "0.12", default-features = false }
-bevy_math = { version = "0.12", default-features = false }
 bevy_reflect = { version = "0.12", default-features = false }
 bevy_render = { version = "0.12", default-features = false }
 bevy_transform = { version = "0.12", default-features = false }
-bevy_utils = { version = "0.12", default-features = false }
 bevy_window = { version = "0.12", default-features = false }
 
 bevy_rapier3d = "0.23"

--- a/backends/bevy_picking_ui/Cargo.toml
+++ b/backends/bevy_picking_ui/Cargo.toml
@@ -15,7 +15,6 @@ resolver = "2"
 [dependencies]
 bevy_app = { version = "0.12", default-features = false }
 bevy_ecs = { version = "0.12", default-features = false }
-bevy_math = { version = "0.12", default-features = false }
 bevy_render = { version = "0.12", default-features = false }
 bevy_transform = { version = "0.12", default-features = false }
 bevy_window = { version = "0.12", default-features = false }

--- a/backends/bevy_picking_ui/src/lib.rs
+++ b/backends/bevy_picking_ui/src/lib.rs
@@ -68,6 +68,7 @@ pub fn ui_picking(
     cameras: Query<(Entity, &Camera, Option<&UiCameraConfig>)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     ui_stack: Res<UiStack>,
+    ui_scale: Res<UiScale>,
     mut node_query: Query<NodeQuery>,
     mut output: EventWriter<PointerHits>,
 ) {
@@ -120,24 +121,13 @@ pub fn ui_picking(
                         }
                     }
 
-                    let position = node.global_transform.translation();
-                    let ui_position = position.truncate();
-                    let extents = node.node.size() / 2.0;
-                    let mut min = ui_position - extents;
-                    if let Some(clip) = node.calculated_clip {
-                        min = Vec2::max(min, clip.clip.min);
-                    }
-
-                    // The mouse position relative to the node
-                    // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
-                    let relative_cursor_position = Vec2::new(
-                        (location.position.x - min.x) / node.node.size().x,
-                        (location.position.y - min.y) / node.node.size().y,
-                    );
-
-                    if (0.0..1.).contains(&relative_cursor_position.x)
-                        && (0.0..1.).contains(&relative_cursor_position.y)
-                    {
+                    let node_rect = node.node.logical_rect(node.global_transform);
+                    let visible_rect = node
+                        .calculated_clip
+                        .map(|clip| node_rect.intersect(clip.clip))
+                        .unwrap_or(node_rect);
+                    let cursor_position = location.position / ui_scale.0 as f32;
+                    if visible_rect.contains(cursor_position) {
                         Some(*entity)
                     } else {
                         None

--- a/backends/bevy_picking_ui/src/lib.rs
+++ b/backends/bevy_picking_ui/src/lib.rs
@@ -24,7 +24,6 @@
 
 use bevy_app::prelude::*;
 use bevy_ecs::{prelude::*, query::WorldQuery};
-use bevy_math::prelude::*;
 use bevy_render::{camera::NormalizedRenderTarget, prelude::*};
 use bevy_transform::prelude::*;
 use bevy_ui::{prelude::*, RelativeCursorPosition, UiStack};


### PR DESCRIPTION
 The Bevy UI backend doesn't check for clipping, and allows interaction with clipped non-visible sections of UI nodes.
 
This PR intersects the node rect with its calculated clip rect (if it has one) and then checks if the clipped node contains the cursor.