### PR TITLE
replace all .single calls with matched .get_single calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+- Fixed: replace all `.single` calls with matched `.get_single` calls to avoid crashing in
+  environments where there is no window available
 - Fixed: sprite picking depth is now consistent with other picking backends.
 - Fixed: entities with identical depth could be dropped due to the use of a BTreeMap to sort
   entities by depth. This has been changed to use a sorted Vec, to allow entities with the same

--- a/backends/bevy_picking_raycast/src/lib.rs
+++ b/backends/bevy_picking_raycast/src/lib.rs
@@ -96,7 +96,10 @@ pub fn update_hits(
                     pointer_location.position,
                     camera,
                     transform,
-                    primary_window.single(),
+                    match primary_window.get_single() {
+                        Ok(w) => w,
+                        Err(_) => return None,
+                    },
                 )
                 .map(|ray| (entity, camera, ray, layers))
             })

--- a/backends/bevy_picking_sprite/src/lib.rs
+++ b/backends/bevy_picking_sprite/src/lib.rs
@@ -69,7 +69,10 @@ pub fn sprite_picking(
             .find(|(_, camera, _)| {
                 camera
                     .target
-                    .normalize(Some(primary_window.single()))
+                    .normalize(Some(match primary_window.get_single() {
+                        Ok(w) => w,
+                        Err(_) => return false,
+                    }))
                     .unwrap()
                     == location.target
             })

--- a/backends/bevy_picking_ui/src/lib.rs
+++ b/backends/bevy_picking_ui/src/lib.rs
@@ -85,7 +85,10 @@ pub fn ui_picking(
             })
             .map(|loc| (pointer, loc))
     }) {
-        let window_entity = primary_window.single();
+        let window_entity = match primary_window.get_single() {
+            Ok(w) => w,
+            Err(_) => continue,
+        };
 
         // Find the topmost bevy_ui camera with the same target as this pointer.
         //

--- a/crates/bevy_picking_core/src/pointer.rs
+++ b/crates/bevy_picking_core/src/pointer.rs
@@ -296,7 +296,10 @@ impl Location {
     ) -> bool {
         if camera
             .target
-            .normalize(Some(primary_window.single()))
+            .normalize(Some(match primary_window.get_single() {
+                Ok(w) => w,
+                Err(_) => return false,
+            }))
             .as_ref()
             != Some(&self.target)
         {

--- a/crates/bevy_picking_input/src/mouse.rs
+++ b/crates/bevy_picking_input/src/mouse.rs
@@ -36,7 +36,13 @@ pub fn mouse_pick_events(
             PointerId::Mouse,
             Location {
                 target: RenderTarget::Window(WindowRef::Entity(event.window))
-                    .normalize(Some(windows.single().0))
+                    .normalize(Some(
+                        match windows.get_single() {
+                            Ok(w) => w,
+                            Err(_) => continue,
+                        }
+                        .0,
+                    ))
                     .unwrap(),
                 position: event.position,
             },

--- a/crates/bevy_picking_input/src/touch.rs
+++ b/crates/bevy_picking_input/src/touch.rs
@@ -37,7 +37,13 @@ pub fn touch_pick_events(
         let pointer = PointerId::Touch(touch.id);
         let location = Location {
             target: RenderTarget::Window(WindowRef::Primary)
-                .normalize(Some(windows.single().0))
+                .normalize(Some(
+                    match windows.get_single() {
+                        Ok(w) => w,
+                        Err(_) => continue,
+                    }
+                    .0,
+                ))
                 .unwrap(),
             position: touch.position,
         };


### PR DESCRIPTION
replace all .single calls with matched .get_single calls to avoid Crashing in environments where there is no window available 