### PR TITLE
Use `try_insert` to prevent `panic`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # UNRELEASED
 
+- Fixed: replaced uses of `.insert` with `.try_insert`, where they could potentially panic.
 - Fixed: replace all `.single` calls with matched `.get_single` calls to avoid crashing in
   environments where there is no window available
 - Fixed: sprite picking depth is now consistent with other picking backends.

--- a/backends/bevy_picking_egui/src/lib.rs
+++ b/backends/bevy_picking_egui/src/lib.rs
@@ -67,7 +67,7 @@ pub fn update_settings(
                     .remove::<bevy_picking_selection::NoDeselect>(),
                 false => commands
                     .entity(entity)
-                    .insert(bevy_picking_selection::NoDeselect),
+                    .try_insert(bevy_picking_selection::NoDeselect),
             };
         }
     }

--- a/crates/bevy_picking_core/src/focus.rs
+++ b/crates/bevy_picking_core/src/focus.rs
@@ -217,7 +217,7 @@ pub fn update_interactions(
         if let Ok(mut interaction) = interact.get_mut(hovered_entity) {
             *interaction = new_interaction;
         } else if let Some(mut entity_commands) = commands.get_entity(hovered_entity) {
-            entity_commands.insert(new_interaction);
+            entity_commands.try_insert(new_interaction);
         }
     }
 }

--- a/crates/bevy_picking_highlight/src/lib.rs
+++ b/crates/bevy_picking_highlight/src/lib.rs
@@ -288,7 +288,7 @@ pub fn get_initial_highlight_asset<T: Asset>(
         match highlighting_query.get_mut(entity) {
             Ok(Some(mut highlighting)) => highlighting.initial = material.to_owned(),
             _ => {
-                commands.entity(entity).insert(InitialHighlight {
+                commands.entity(entity).try_insert(InitialHighlight {
                     initial: material.to_owned(),
                 });
             }


### PR DESCRIPTION
When using `insert` instead of `try_insert` on `EntityCommand`, it can happen that the system panics, when the entity does not exist, even when the `EntityCommand` has been accessed with `get_entity(...)`. The following example demonstrates the problem:

```rust
if let Some(mut entity_commands) = commands.get_entity(entity) {
    // at this point some other system despawns `entity` concurrently
    entity_commands.insert(bundle);
    //              ^^^^^^ this will panic
}
```

This is also documented in the official bevy docs: https://docs.rs/bevy/0.12.1/bevy/ecs/system/struct.Commands.html#method.get_entity

## Other occurrences of `.insert` (where _probably_ no change is necessary)
I've also looked at other occurrences of `.insert` on `EntityCommand` in the code, but I don't think we will have problems there, when `.insert` is used, because it is directly retrieved from the `Query` of the same system, but I'm not sure. What do you think?

Here are other locations of `.insert`:
https://github.com/aevyrie/bevy_mod_picking/blob/1471a9f83435f3fdd43829b90391e6ab965e0e73/backends/bevy_picking_egui/src/lib.rs#L64-L71

https://github.com/aevyrie/bevy_mod_picking/blob/1471a9f83435f3fdd43829b90391e6ab965e0e73/crates/bevy_picking_highlight/src/lib.rs#L287-L296
