### PR TITLE
Implement bevy_xpbd_3d picking backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # UNRELEASED
 
+- Added: `bevy_xpbd_3d` picking backend, available behind the optional `backend_xpbd` feature.
 - Added: support for touch inputs across multiple windows.
 - Changed: simplified debug settings and examples. Debug settings can be changed with the
   `DebugPickingMode` resource.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ all = [
     "backend_rapier",
     "backend_sprite",
     "backend_egui",
+    "backend_xpbd",
 ]
 default = [
     "backend_raycast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ bevy_window = { version = "0.13", default-features = false }
 bevy_eventlistener = "0.7"
 bevy_egui = { optional = true, version = "0.25" }
 bevy_rapier3d = { optional = true, version = "0.25" }
+bevy_xpbd_3d = { optional = true, version = "0.4" }
 
 # Local
 bevy_picking_core = { path = "crates/bevy_picking_core", version = "0.17" }
@@ -47,6 +48,7 @@ bevy_picking_ui = { optional = true, path = "backends/bevy_picking_ui", version 
 bevy_picking_rapier = { optional = true, path = "backends/bevy_picking_rapier", version = "0.17" }
 bevy_picking_sprite = { optional = true, path = "backends/bevy_picking_sprite", version = "0.17" }
 bevy_picking_egui = { optional = true, path = "backends/bevy_picking_egui", version = "0.17" }
+bevy_picking_xpbd = { optional = true, path = "backends/bevy_picking_xpbd", version = "0.17" }
 
 [dev-dependencies]
 bevy = { version = "0.13", default-features = false, features = [
@@ -94,6 +96,7 @@ backend_rapier = ["bevy_picking_rapier", "bevy_rapier3d"]
 backend_sprite = ["bevy_picking_sprite", "bevy_picking_highlight/sprite"]
 backend_bevy_ui = ["bevy_picking_ui", "bevy_ui"]
 backend_egui = ["bevy_picking_egui", "bevy_egui"]
+backend_xpbd = ["bevy_picking_xpbd", "bevy_xpbd_3d"]
 
 [[example]]
 name = "rapier"
@@ -124,3 +127,8 @@ required-features = ["backend_egui"]
 name = "split_screen"
 path = "examples/split_screen.rs"
 required-features = ["backend_egui"]
+
+[[example]]
+name = "xpbd"
+path = "examples/xpbd.rs"
+required-features = ["backend_xpbd"]

--- a/backends/bevy_picking_xpbd/Cargo.toml
+++ b/backends/bevy_picking_xpbd/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bevy_picking_xpbd"
+version = "0.17.0"
+edition = "2021"
+authors = ["Aevyrie <aevyrie@gmail.com>, Affinator"]
+license = "MIT OR Apache-2.0"
+description = "A modular picking plugin for Bevy."
+repository = "https://github.com/aevyrie/bevy_mod_picking/"
+keywords = ["gamedev", "picking", "bevy", "input", "eventlistener", "xpbd"]
+categories = ["game-engines"]
+resolver = "2"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bevy_app = { version = "0.13", default-features = false }
+bevy_ecs = { version = "0.13", default-features = false }
+bevy_math = { version = "0.13", default-features = false }
+bevy_reflect = { version = "0.13", default-features = false }
+bevy_render = { version = "0.13", default-features = false }
+bevy_transform = { version = "0.13", default-features = false }
+bevy_utils = { version = "0.13", default-features = false }
+bevy_window = { version = "0.13", default-features = false }
+
+bevy_xpbd_3d = "0.4"
+# Local
+bevy_picking_core = { path = "../../crates/bevy_picking_core", version = "0.17" }

--- a/backends/bevy_picking_xpbd/src/lib.rs
+++ b/backends/bevy_picking_xpbd/src/lib.rs
@@ -1,0 +1,137 @@
+//! A raycasting backend for `bevy_mod_picking` that uses `xpbd` for raycasting.
+//!
+//! # Usage
+//!
+//! If a pointer passes through this camera's render target, it will
+//! automatically shoot rays into the xpbd scene and will be able to pick things.
+//!
+//! To ignore an entity, you can add [`Pickable::IGNORE`] to it, and it will be ignored during
+//! raycasting.
+//!
+//! For fine-grained control, see the [`XpbdBackendSettings::require_markers`] setting.
+//!
+//! ## Limitations
+//!
+//! Because raycasting is expensive, only the closest intersection will be reported. This means that
+//! unlike some UI, you cannot hover multiple xpbd objects with a single pointer by configuring
+//! the [`Pickable`] component to not block lower elements but still emit events. As mentioned
+//! above, all that is supported is completely ignoring an entity with [`Pickable::IGNORE`].
+//!
+//! This is probably not a meaningful limitation, as the feature is usually only used in UI where
+//! you might want a pointer to be able to pick multiple elements that are on top of each other. If
+//! are trying to build a UI out of xpbd entities, beware, I suppose.
+
+#![allow(clippy::type_complexity)]
+#![allow(clippy::too_many_arguments)]
+#![deny(missing_docs)]
+
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_render::{prelude::*, view::RenderLayers};
+
+use bevy_picking_core::backend::prelude::*;
+use bevy_xpbd_3d::prelude::*;
+
+// Re-export for users who want this
+pub use bevy_xpbd_3d;
+
+/// Commonly used imports.
+pub mod prelude {
+    pub use crate::{XpbdBackend, XpbdBackendSettings, XpbdPickable};
+}
+
+/// Adds the `xpbd_3d` raycasting picking backend to your app.
+#[derive(Clone)]
+pub struct XpbdBackend;
+impl Plugin for XpbdBackend {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<XpbdBackendSettings>()
+            .add_systems(PreUpdate, update_hits.in_set(PickSet::Backend))
+            .register_type::<XpbdBackendSettings>()
+            .register_type::<XpbdPickable>();
+    }
+}
+
+/// Runtime settings for the [`XpbdBackend`].
+#[derive(Resource, Default, Reflect)]
+#[reflect(Resource, Default)]
+pub struct XpbdBackendSettings {
+    /// When set to `true` raycasting will only happen between cameras and entities marked with
+    /// [`XpbdPickable`]. Off by default. This setting is provided to give you fine-grained
+    /// control over which cameras and entities should be used by the xpbd backend at runtime.
+    pub require_markers: bool,
+}
+
+/// Optional. Marks cameras and target entities that should be used in the xpbd picking backend.
+/// Only needed if [`XpbdBackendSettings::require_markers`] is set to true.
+#[derive(Debug, Clone, Default, Component, Reflect)]
+#[reflect(Component, Default)]
+pub struct XpbdPickable;
+
+/// Raycasts into the scene using [`XpbdBackendSettings`] and [`PointerLocation`]s, then outputs
+/// [`PointerHits`].
+pub fn update_hits(
+    picking_cameras: Query<(&Camera, Option<&XpbdPickable>, Option<&RenderLayers>)>,
+    ray_map: Res<RayMap>,
+    pickables: Query<&Pickable>,
+    marked_targets: Query<&XpbdPickable>,
+    layers: Query<&RenderLayers>,
+    backend_settings: Res<XpbdBackendSettings>,
+    spatial_query: Option<Res<SpatialQueryPipeline>>,
+    mut output_events: EventWriter<PointerHits>,
+) {
+    let Some(spatial_query) = spatial_query else {
+        return;
+    };
+
+    for (&ray_id, &ray) in ray_map.map().iter() {
+        let Ok((camera, cam_pickable, cam_layers)) = picking_cameras.get(ray_id.camera) else {
+            continue;
+        };
+        if backend_settings.require_markers && cam_pickable.is_none() || !camera.is_active {
+            continue;
+        }
+
+        let cam_layers = cam_layers.copied().unwrap_or_default();
+
+        if let Some((entity, hit_data)) = spatial_query
+            .cast_ray_predicate(
+                ray.origin,
+                ray.direction,
+                f32::MAX,
+                true,
+                SpatialQueryFilter::default(),
+                &|entity| {
+                    let marker_requirement =
+                        !backend_settings.require_markers || marked_targets.get(entity).is_ok();
+
+                    // Other entities missing render layers are on the default layer 0
+                    let entity_layers = layers.get(entity).copied().unwrap_or_default();
+                    let render_layers_match = cam_layers.intersects(&entity_layers);
+
+                    let pickable = pickables
+                        .get(entity)
+                        .map(|p| *p != Pickable::IGNORE)
+                        .unwrap_or(true);
+                    marker_requirement && render_layers_match && pickable
+                },
+            )
+            .map(|ray_hit_data| {
+                let hit_data = HitData::new(
+                    ray_id.camera,
+                    ray_hit_data.time_of_impact,
+                    Some(ray.origin + (ray.direction * ray_hit_data.time_of_impact)),
+                    Some(ray_hit_data.normal),
+                );
+                (ray_hit_data.entity, hit_data)
+            })
+        {
+            output_events.send(PointerHits::new(
+                ray_id.pointer,
+                vec![(entity, hit_data)],
+                camera.order as f32,
+            ));
+        }
+    }
+}

--- a/examples/xpbd.rs
+++ b/examples/xpbd.rs
@@ -1,0 +1,71 @@
+//! Demonstrates how to use the xpbd picking backend.
+
+use bevy::prelude::*;
+use bevy_mod_picking::prelude::*;
+use bevy_xpbd_3d::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins.set(low_latency_window_plugin()),
+            // We want to disable the raycast backend because it is enabled by default. All supplied
+            // backends are optional. In your app, you can disable the default features of the
+            // plugin and only enable the backends you want to use. Picking will still work if both
+            // backends are enabled, but that would mean we wouldn't be able to test the xpbd
+            // backend in isolation.
+            DefaultPickingPlugins.build().disable::<RaycastBackend>(),
+            PhysicsPlugins::default(),
+            PhysicsDebugPlugin::default(),
+        ))
+        .insert_resource(XpbdBackendSettings {
+            require_markers: true, // Optional: only needed when you want fine-grained control over which cameras and entities should be used with the xpbd picking backend. This is disabled by default, and no marker components are required on cameras or colliders. This resource is inserted by default, you only need to add it if you want to override the default settings.
+        })
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(bevy_render::mesh::PlaneMeshBuilder {
+                half_size: Vec2::splat(2.5),
+                ..default()
+            }),
+            material: materials.add(Color::WHITE),
+            ..default()
+        },
+        Collider::cuboid(5.0, 0.01, 5.0),
+        PickableBundle::default(), // Optional: adds selection, highlighting, and helper components.
+        XpbdPickable, // Optional: only required if `XpbdBackendSettings::require_markers`
+    ));
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Cuboid::default()),
+            material: materials.add(Color::WHITE),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0),
+            ..default()
+        },
+        Collider::cuboid(1.0, 1.0, 1.0),
+        PickableBundle::default(), // Optional: adds selection, highlighting, and helper components.
+        XpbdPickable, // Optional: only required if `XpbdBackendSettings::require_markers`
+    ));
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        XpbdPickable, // Optional: only required if `XpbdBackendSettings::require_markers`
+    ));
+}

--- a/examples/xpbd.rs
+++ b/examples/xpbd.rs
@@ -17,6 +17,7 @@ fn main() {
             PhysicsPlugins::default(),
             PhysicsDebugPlugin::default(),
         ))
+        .insert_resource(DebugPickingMode::Normal)
         .insert_resource(XpbdBackendSettings {
             require_markers: true, // Optional: only needed when you want fine-grained control over which cameras and entities should be used with the xpbd picking backend. This is disabled by default, and no marker components are required on cameras or colliders. This resource is inserted by default, you only need to add it if you want to override the default settings.
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,8 @@ pub mod backends {
     pub use bevy_picking_sprite as sprite;
     #[cfg(feature = "backend_bevy_ui")]
     pub use bevy_picking_ui as bevy_ui;
+    #[cfg(feature = "backend_xpbd")]
+    pub use bevy_picking_xpbd as xpbd;
 }
 
 /// Common imports
@@ -235,6 +237,8 @@ pub mod prelude {
     pub use backends::shader::prelude::*;
     #[cfg(feature = "backend_sprite")]
     pub use backends::sprite::prelude::*;
+    #[cfg(feature = "backend_xpbd")]
+    pub use backends::xpbd::prelude::*;
 }
 
 /// Makes an entity pickable.
@@ -310,6 +314,10 @@ impl bevy_app::PluginGroup for DefaultPickingPlugins {
         #[cfg(feature = "backend_rapier")]
         {
             builder = builder.add(bevy_picking_rapier::RapierBackend);
+        }
+        #[cfg(feature = "backend_xpbd")]
+        {
+            builder = builder.add(bevy_picking_xpbd::XpbdBackend);
         }
         #[cfg(feature = "backend_shader")]
         {


### PR DESCRIPTION
Hi,
after my PR regarding a raycast with predicate was merged to bevy_xpbd, I think this PR is ready for a review.

Edit: I am currently migrating to bevy 0.13. The code is already working, but clippy will not be happy.

## Objective
Implement a bevy_xpbd picking backend as requested in https://github.com/aevyrie/bevy_mod_picking/issues/286

## Solution
- I mainly mirrored the functionality and example of the rapier backend.
- I therefore implemented a cast_ray_predicate function in bevy_xpbd, which was released with version 0.4 of xpbd.