### PR TITLE
Bumped bevy_egui to 0.26 in egui backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bevy_utils = { version = "0.13", default-features = false }
 bevy_window = { version = "0.13", default-features = false }
 
 bevy_eventlistener = "0.7"
-bevy_egui = { optional = true, version = "0.25" }
+bevy_egui = { optional = true, version = "0.26" }
 bevy_rapier3d = { optional = true, version = "0.25" }
 bevy_xpbd_3d = { optional = true, version = "0.4" }
 

--- a/backends/bevy_picking_egui/Cargo.toml
+++ b/backends/bevy_picking_egui/Cargo.toml
@@ -18,7 +18,7 @@ bevy_ecs = { version = "0.13", default-features = false }
 bevy_reflect = { version = "0.13", default-features = false }
 bevy_render = { version = "0.13", default-features = false }
 
-bevy_egui = "0.25"
+bevy_egui = "0.26"
 # Local
 bevy_picking_core = { path = "../../crates/bevy_picking_core", version = "0.18" }
 bevy_picking_selection = { path = "../../crates/bevy_picking_selection", optional = true, version = "0.18" }


### PR DESCRIPTION
Bumped bevy_egui to 0.26. Fixes dependency issue when using bevy_egui 0.26 in project. 