### PR TITLE
egui_backend -> backend_egui in egui.rs example

### DIFF
--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -1,6 +1,6 @@
 //! This example demonstrates how backends can be mixed and matched, specifically with egui. Here,
 //! we are using the egui backend, which is enabled automatically in `DefaultPickingPlugins` when
-//! the "egui_backend" feature is enabled. The egui backend will automatically apply a `NoDeselect`
+//! the "backend_egui" feature is enabled. The egui backend will automatically apply a `NoDeselect`
 //! component to the egui entity, which allows you to interact with the UI without deselecting
 //! anything in the 3d scene.
 


### PR DESCRIPTION
Turned the backend<>egui around as the feature's name is backend_egui and not backend_egui, see https://docs.rs/crate/bevy_mod_picking/0.20.1/features