### PR TITLE
Update to bevy_egui 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ bevy_color = { version = "0.14.0", optional = true, default-features = false }
 bevy_ui = { version = "0.14.0", optional = true, default-features = false }
 
 bevy_eventlistener = "0.8.0"
-bevy_egui = { optional = true, version = "0.28.0" }          # >=0.28,  <=0.XX
+bevy_egui = { optional = true, version = "0.30" }
 bevy_rapier3d = { optional = true, version = "0.27.0-rc.1" }
 bevy_xpbd_3d = { optional = true, version = "0.5.0" }
 avian3d = { optional = true, version = '0.1' }

--- a/backends/bevy_picking_egui/Cargo.toml
+++ b/backends/bevy_picking_egui/Cargo.toml
@@ -18,7 +18,7 @@ bevy_ecs = { version = "0.14.0", default-features = false }
 bevy_reflect = { version = "0.14.0", default-features = false }
 bevy_render = { version = "0.14.0", default-features = false }
 
-bevy_egui = "0.28"
+bevy_egui = "0.30"
 # Local
 bevy_picking_core = { path = "../../crates/bevy_picking_core", version = "0.20.0" }
 bevy_picking_selection = { path = "../../crates/bevy_picking_selection", optional = true, version = "0.20.0" }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -306,7 +306,7 @@ pub fn debug_draw_egui(
         let NormalizedRenderTarget::Window(window_ref) = location.target else {
             continue;
         };
-        let ctx = egui.ctx_for_window_mut(window_ref.entity());
+        let ctx = egui.ctx_for_entity_mut(window_ref.entity());
         let to_egui_pos = |v: Vec2| egui::pos2(v.x, v.y);
         let dbg_painter = ctx.layer_painter(egui::LayerId::debug());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,8 +256,6 @@ pub mod prelude {
     pub use backends::rapier::prelude::*;
     #[cfg(feature = "backend_raycast")]
     pub use backends::raycast::prelude::*;
-    #[cfg(feature = "backend_shader")]
-    pub use backends::shader::prelude::*;
     #[cfg(feature = "backend_sprite")]
     pub use backends::sprite::prelude::*;
     #[cfg(feature = "backend_xpbd")]
@@ -341,10 +339,6 @@ impl bevy_app::PluginGroup for DefaultPickingPlugins {
         #[cfg(feature = "backend_xpbd")]
         {
             builder = builder.add(bevy_picking_xpbd::XpbdBackend);
-        }
-        #[cfg(feature = "backend_shader")]
-        {
-            builder = builder.add(bevy_picking_shader::ShaderBackend);
         }
         #[cfg(feature = "backend_sprite")]
         {


### PR DESCRIPTION
I think _technically_ these could be ranged to `>= 0.29, <= 0.30`, as only `0.29` has the breaking API change. I can put the shader picking stuff back, too.